### PR TITLE
add polyline tool and possibility to override default tools props

### DIFF
--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl"
+      crossorigin="anonymous"
+    />
+    <title>Larvitar - Basic rendering example</title>
+  </head>
+
+  <body width="100%" height="100%">
+    <section>
+      <div width="100%" height="100%" style="background-color: black">
+        <div
+          id="viewer"
+          style="
+            color: white;
+            display: inline-block;
+            background-color: rgb(0, 0, 0);
+            width: 49.5%;
+            height: 500px;
+            vertical-align: top;
+          "
+        >
+          <div>
+            <p>
+              Segment an area by drawing a polyline. Click near an existing
+              point to close, or double click.
+            </p>
+          </div>
+        </div>
+        <div
+          id="app-container-dx"
+          style="
+            display: inline-block;
+            background-color: rgb(255, 255, 255);
+            width: 49.5%;
+            height: 100%;
+          "
+        >
+          <pre><code class="javascript" data-lang="javascript">
+          <p style="font-size:0.8vw;">
+            let demoFiles = [];
+            let counter = 0;
+      
+            const getDemoFileNames = function () {
+              let demoFileList = [];
+              for (let i = 1; i < 25; i++) {
+                let filename = "anon" + i;
+                demoFileList.push(filename);
+              }
+              return demoFileList;
+            };
+      
+            // init all
+            larvitar.initLarvitarStore();
+            larvitar.initializeImageLoader();
+            larvitar.initializeCSTools();
+            larvitar.larvitar_store.addViewport("viewer");
+      
+            async function createFile(fileName, cb) {
+              let response = await fetch("./demo/" + fileName);
+              let data = await response.blob();
+              let file = new File([data], fileName);
+              demoFiles.push(file);
+              counter++;
+              if (counter == 24) {
+                cb();
+              }
+            }
+      
+            function renderSerie() {
+              larvitar.resetImageParsing();
+              larvitar.readFiles(demoFiles, function (seriesStack, err) {
+                let seriesId = _.keys(seriesStack)[0];
+                let serie = seriesStack[seriesId];
+                larvitar.renderImage(serie, "viewer");
+                // override some default tools props before adding
+                larvitar.setDefaultToolsProps([
+                  { name: "Wwwc", defaultActive: false },
+                  { name: "PolylineScissors", defaultActive: true }
+                ]);
+                larvitar.addDefaultTools();
+              });
+            }
+      
+            let demoFileList = getDemoFileNames();
+      
+            _.each(demoFileList, function (demoFile) {
+              createFile(demoFile, renderSerie);
+            });
+        </p>
+        </code></pre>
+        </div>
+      </div>
+    </section>
+
+    <script src="./larvitar.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
+
+    <script>
+      let demoFiles = [];
+      let counter = 0;
+
+      const getDemoFileNames = function () {
+        let demoFileList = [];
+        for (let i = 1; i < 25; i++) {
+          let filename = "anon" + i;
+          demoFileList.push(filename);
+        }
+        return demoFileList;
+      };
+
+      // init all
+      larvitar.initLarvitarStore();
+      larvitar.initializeImageLoader();
+      larvitar.initializeCSTools();
+      larvitar.larvitar_store.addViewport("viewer");
+
+      async function createFile(fileName, cb) {
+        let response = await fetch("./demo/" + fileName);
+        let data = await response.blob();
+        let file = new File([data], fileName);
+        demoFiles.push(file);
+        counter++;
+        if (counter == 24) {
+          cb();
+        }
+      }
+
+      function renderSerie() {
+        larvitar.resetImageParsing();
+        larvitar.readFiles(demoFiles, function (seriesStack, err) {
+          let seriesId = _.keys(seriesStack)[0];
+          let serie = seriesStack[seriesId];
+          larvitar.renderImage(serie, "viewer");
+          // override some default tools props before adding
+          larvitar.setDefaultToolsProps([
+            { name: "Wwwc", defaultActive: false },
+            { name: "PolylineScissors", defaultActive: true }
+          ]);
+          larvitar.addDefaultTools();
+        });
+      }
+
+      let demoFileList = getDemoFileNames();
+
+      _.each(demoFileList, function (demoFile) {
+        createFile(demoFile, renderSerie);
+      });
+    </script>
+  </body>
+</html>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -33,10 +33,22 @@
           </button>
         </div>
 
-        <div class="btn-group-vertical" role="group" aria-label="Reslice example">
+        <div
+          class="btn-group-vertical"
+          role="group"
+          aria-label="Reslice example"
+        >
           <button type="button" class="btn btn-primary">
             <a href="reslice.html"
               ><span style="color: white">Reslice and render a dicom</span>
+            </a>
+          </button>
+        </div>
+
+        <div class="btn-group-vertical" role="group" aria-label="Tools example">
+          <button type="button" class="btn btn-primary">
+            <a href="defaultTools.html"
+              ><span style="color: white">Add default tools</span>
             </a>
           </button>
         </div>

--- a/imaging/tools/polygonSegmentationMixin.js
+++ b/imaging/tools/polygonSegmentationMixin.js
@@ -1,0 +1,241 @@
+import cornerstoneTools from "cornerstone-tools";
+
+const external = cornerstoneTools.external;
+const draw = cornerstoneTools.importInternal("drawing/draw");
+const drawJoinedLines = cornerstoneTools.importInternal(
+  "drawing/drawJoinedLines"
+);
+const getNewContext = cornerstoneTools.importInternal("drawing/getNewContext");
+const { getDiffBetweenPixelData } = cornerstoneTools.importInternal(
+  "util/segmentationUtils"
+);
+const { getters, setters } = cornerstoneTools.getModule("segmentation");
+
+/**
+ * Global var, identify when first point has already been placed
+ */
+let isDrawing = false;
+
+/**
+ * Override for `freehandSegmentationMixin`'s `renderToolData` method to render a polyline instead
+ * of a freehand region with the first and last point connected. Apply after the `freehandSegmentationMixin`.
+ *
+ * @override
+ * @param {Object} evt The cornerstone render event.
+ * @returns {null}
+ */
+function renderToolData(evt) {
+  const eventData = evt.detail;
+  const { element } = eventData;
+  const color = getters.brushColor(element, true);
+  const context = getNewContext(eventData.canvasContext.canvas);
+  const handles = this.handles;
+
+  draw(context, context => {
+    const isNotTheFirstHandle = handles.points.length > 1;
+
+    if (isNotTheFirstHandle) {
+      for (let j = 0; j < handles.points.length; j++) {
+        const lines = [...handles.points[j].lines];
+
+        drawJoinedLines(context, element, this.handles.points[j], lines, {
+          color
+        });
+      }
+    }
+  });
+}
+
+/**
+ * Returns a handle of a particular tool if it is close to the mouse cursor
+ *
+ * @private
+ * @param {Object} element - The element on which the roi is being drawn.
+ * @param {Object} data      Data object associated with the tool.
+ * @param {*} coords
+ * @returns {Number|Object|Boolean}
+ */
+function _pointNearHandle(element, data, coords) {
+  if (data.handles === undefined || data.handles.points === undefined) {
+    return;
+  }
+
+  if (data.visible === false) {
+    return;
+  }
+
+  for (let i = 0; i < data.handles.points.length; i++) {
+    const handleCanvas = external.cornerstone.pixelToCanvas(
+      element,
+      data.handles.points[i]
+    );
+
+    if (external.cornerstoneMath.point.distance(handleCanvas, coords) < 6) {
+      return true;
+    }
+  }
+}
+
+/**
+ * Entry point, manage workflow starting / ending
+ * @param {Object} evt
+ */
+
+function _checkIfDrawing(evt) {
+  const { currentPoints, element } = evt.detail;
+  const coords = currentPoints.canvas;
+  let data = this;
+
+  if (isDrawing && _pointNearHandle(element, data, coords)) {
+    _applyStrategy.call(this, evt);
+  } else if (isDrawing) {
+    _setHandlesAndUpdate.call(this, evt);
+  } else {
+    isDrawing = true;
+    _startOutliningRegion.call(this, evt);
+  }
+}
+
+/**
+ * Sets the start handle point and claims the eventDispatcher event
+ *
+ * @private
+ * @param {*} evt // mousedown, touchstart, click
+ * @returns {void|null}
+ */
+function _startOutliningRegion(evt) {
+  const element = evt.detail.element;
+  const image = evt.detail.currentPoints.image;
+  const points = this.handles.points;
+
+  points.push({
+    x: image.x,
+    y: image.y,
+    lines: []
+  });
+
+  this.currentHandle += 1;
+
+  external.cornerstone.updateImage(element);
+}
+
+/**
+ * This function will update the handles and updateImage to force re-draw
+ *
+ * @private
+ * @method _setHandlesAndUpdate
+ * @param {(CornerstoneTools.event#TOUCH_DRAG|CornerstoneTools.event#MOUSE_DRAG|CornerstoneTools.event#MOUSE_MOVE)} evt  Interaction event emitted by an enabledElement
+ * @returns {void}
+ */
+function _setHandlesAndUpdate(evt) {
+  const eventData = evt.detail;
+  const element = evt.detail.element;
+
+  this._addPoint(eventData);
+  external.cornerstone.updateImage(element);
+}
+
+/**
+ * Event handler for MOUSE_UP/TOUCH_END during handle drag event loop.
+ *
+ * @private
+ * @method _applyStrategy
+ * @param {(CornerstoneTools.event#MOUSE_UP|CornerstoneTools.event#TOUCH_END)} evt Interaction event emitted by an enabledElement
+ * @returns {void}
+ */
+function _applyStrategy(evt) {
+  const points = this.handles.points;
+  const { element } = evt.detail;
+
+  const { labelmap2D, labelmap3D, currentImageIdIndex } = getters.labelmap2D(
+    element
+  );
+
+  const pixelData = labelmap2D.pixelData;
+  const previousPixeldata = pixelData.slice();
+
+  const operationData = {
+    points,
+    pixelData,
+    segmentIndex: labelmap3D.activeSegmentIndex,
+    segmentationMixinType: `freehandSegmentationMixin`
+  };
+
+  this.applyActiveStrategy(evt, operationData);
+
+  const operation = {
+    imageIdIndex: currentImageIdIndex,
+    diff: getDiffBetweenPixelData(previousPixeldata, pixelData)
+  };
+
+  setters.pushState(this.element, [operation]);
+
+  // Invalidate the brush tool data so it is redrawn
+  setters.updateSegmentsOnLabelmap2D(labelmap2D);
+  external.cornerstone.updateImage(element);
+
+  this._resetHandles();
+}
+
+/**
+ * Sets the start and end handle points to empty objects
+ *
+ * @private
+ * @method _resetHandles
+ * @returns {undefined}
+ */
+function _resetHandles() {
+  this.handles = {
+    points: []
+  };
+
+  isDrawing = false;
+
+  this.currentHandle = 0;
+}
+
+/**
+ * Adds a point on mouse click in polygon mode.
+ *
+ * @private
+ * @param {Object} evt - data object associated with an event.
+ * @returns {void}
+ */
+function _addPoint(evt) {
+  const points = this.handles.points;
+
+  if (points.length) {
+    // Add the line from the current handle to the new handle
+    points[this.currentHandle - 1].lines.push({
+      x: evt.currentPoints.image.x,
+      y: evt.currentPoints.image.y,
+      lines: []
+    });
+  }
+
+  // Add the new handle
+  points.push({
+    x: evt.currentPoints.image.x,
+    y: evt.currentPoints.image.y,
+    lines: []
+  });
+
+  // Increment the current handle value
+  this.currentHandle += 1;
+
+  // Force onImageRendered to fire
+  external.cornerstone.updateImage(evt.element);
+}
+
+/**
+ * @mixin polygonSegmentationMixin - segmentation operations for polyline
+ * @memberof Mixins
+ */
+export default {
+  mouseClickCallback: _checkIfDrawing,
+  initializeMixin: _resetHandles,
+  renderToolData,
+  _resetHandles,
+  _addPoint,
+  _applyStrategy
+};

--- a/imaging/tools/polylineScissorsTool.js
+++ b/imaging/tools/polylineScissorsTool.js
@@ -1,0 +1,52 @@
+import cornerstoneTools from "cornerstone-tools";
+import {
+  fillInsideFreehand,
+  fillOutsideFreehand,
+  eraseOutsideFreehand,
+  eraseInsideFreehand
+} from "./strategies"; // cannot import strategies in other way 🤷
+import polygonSegmentationMixin from "./polygonSegmentationMixin";
+
+const BaseTool = cornerstoneTools.importInternal("base/BaseTool");
+const { rectangleRoiCursor } = cornerstoneTools.importInternal("tools/cursors");
+
+// Register custom mixin
+cornerstoneTools.register(
+  "mixin",
+  "polygonSegmentationMixin",
+  polygonSegmentationMixin
+);
+
+/**
+ * @public
+ * @class PolylineScissorsTool
+ * @memberof Tools
+ * @classdesc Tool for manipulating labelmap data by drawing a polyline polygon.
+ * @extends Tools.Base.BaseTool
+ */
+export default class PolylineScissorsTool extends BaseTool {
+  /** @inheritdoc */
+  constructor(props = {}) {
+    const defaultProps = {
+      name: "PolylineScissors",
+      strategies: {
+        FILL_INSIDE: fillInsideFreehand,
+        FILL_OUTSIDE: fillOutsideFreehand,
+        ERASE_OUTSIDE: eraseOutsideFreehand,
+        ERASE_INSIDE: eraseInsideFreehand
+      },
+      cursors: {
+        FILL_INSIDE: rectangleRoiCursor,
+        FILL_OUTSIDE: rectangleRoiCursor,
+        ERASE_OUTSIDE: rectangleRoiCursor,
+        ERASE_INSIDE: rectangleRoiCursor
+      },
+      defaultStrategy: "FILL_INSIDE",
+      supportedInteractionTypes: ["Mouse", "Touch"],
+      svgCursor: rectangleRoiCursor,
+      mixins: ["polygonSegmentationMixin"]
+    };
+
+    super(props, defaultProps);
+  }
+}

--- a/imaging/tools/strategies/eraseFreehand.js
+++ b/imaging/tools/strategies/eraseFreehand.js
@@ -1,0 +1,77 @@
+import cornerstoneTools from "cornerstone-tools";
+
+const {
+  getBoundingBoxAroundPolygon,
+  eraseInsideShape,
+  eraseOutsideShape
+} = cornerstoneTools.importInternal("util/segmentationUtils");
+
+const isPointInPolygon = cornerstoneTools.importInternal(
+  "util/isPointInPolygon"
+);
+
+const getLogger = cornerstoneTools.importInternal("util/getLogger");
+
+const logger = getLogger("util:segmentation:operations:eraseInsideFreehand");
+
+/**
+ * Erase all pixels labeled with the activeSegmentIndex,
+ * in the region defined by evt.operationData.points.
+ * @param  {} evt The Cornerstone event.
+ * @param  {} operationData An object containing the `pixelData` to
+ *                          modify, the `segmentIndex` and the `points` array.
+ * @returns {null}
+ */
+function eraseFreehand(evt, operationData, inside = true) {
+  const { points, segmentationMixinType } = operationData;
+
+  if (segmentationMixinType !== `freehandSegmentationMixin`) {
+    logger.error(
+      `eraseInsideFreehand operation requires freehandSegmentationMixin operationData, recieved ${segmentationMixinType}`
+    );
+
+    return;
+  }
+
+  const { image } = evt.detail;
+  const vertices = points.map(a => [a.x, a.y]);
+  const [topLeft, bottomRight] = getBoundingBoxAroundPolygon(vertices, image);
+
+  inside
+    ? eraseInsideShape(
+        evt,
+        operationData,
+        point => isPointInPolygon([point.x, point.y], vertices),
+        topLeft,
+        bottomRight
+      )
+    : eraseOutsideShape(
+        evt,
+        operationData,
+        point => isPointInPolygon([point.x, point.y], vertices),
+        topLeft,
+        bottomRight
+      );
+}
+
+/**
+ * Erase all pixels inside/outside the region defined by `operationData.points`.
+ * @param  {} evt The Cornerstone event.
+ * @param {}  operationData An object containing the `pixelData` to
+ *                          modify, the `segmentIndex` and the `points` array.
+ * @returns {null}
+ */
+export function eraseInsideFreehand(evt, operationData) {
+  eraseFreehand(evt, operationData, true);
+}
+
+/**
+ * Erase all pixels outside the region defined by `operationData.points`.
+ * @param  {} evt The Cornerstone event.
+ * @param  {} operationData An object containing the `pixelData` to
+ *                          modify, the `segmentIndex` and the `points` array.
+ * @returns {null}
+ */
+export function eraseOutsideFreehand(evt, operationData) {
+  eraseFreehand(evt, operationData, false);
+}

--- a/imaging/tools/strategies/fillFreehand.js
+++ b/imaging/tools/strategies/fillFreehand.js
@@ -1,0 +1,80 @@
+import cornerstoneTools from "cornerstone-tools";
+
+const {
+  getBoundingBoxAroundPolygon,
+  fillInsideShape,
+  fillOutsideShape
+} = cornerstoneTools.importInternal("util/segmentationUtils");
+
+const isPointInPolygon = cornerstoneTools.importInternal(
+  "util/isPointInPolygon"
+);
+
+const getLogger = cornerstoneTools.importInternal("util/getLogger");
+
+const logger = getLogger("util:segmentation:operations:fillInsideFreehand");
+
+/**
+ * Fill all pixels inside/outside the region defined by
+ * `operationData.points` with the `activeSegmentIndex` value.
+ * @param  {} evt The Cornerstone event.
+ * @param  {} operationData An object containing the `pixelData` to
+ *                          modify, the `segmentIndex` and the `points` array.
+ * @returns {null}
+ */
+function fillFreehand(evt, operationData, inside = true) {
+  const { points, segmentationMixinType } = operationData;
+
+  if (segmentationMixinType !== `freehandSegmentationMixin`) {
+    logger.error(
+      `eraseInsideFreehand operation requires freehandSegmentationMixin operationData, recieved ${segmentationMixinType}`
+    );
+
+    return;
+  }
+
+  // Obtain the bounding box of the entire drawing so that
+  // we can subset our search. Outside of the bounding box,
+  // everything is outside of the polygon.
+  const { image } = evt.detail;
+  const vertices = points.map(a => [a.x, a.y]);
+  const [topLeft, bottomRight] = getBoundingBoxAroundPolygon(vertices, image);
+
+  inside
+    ? fillInsideShape(
+        evt,
+        operationData,
+        point => isPointInPolygon([point.x, point.y], vertices),
+        topLeft,
+        bottomRight
+      )
+    : fillOutsideShape(
+        evt,
+        operationData,
+        point => isPointInPolygon([point.x, point.y], vertices),
+        topLeft,
+        bottomRight
+      );
+}
+
+/**
+ * Fill all pixels inside/outside the region defined by `operationData.points`.
+ * @param  {} evt The Cornerstone event.
+ * @param {}  operationData An object containing the `pixelData` to
+ *                          modify, the `segmentIndex` and the `points` array.
+ * @returns {null}
+ */
+export function fillInsideFreehand(evt, operationData) {
+  fillFreehand(evt, operationData, true);
+}
+
+/**
+ * Fill all pixels outside the region defined by `operationData.points`.
+ * @param  {} evt The Cornerstone event.
+ * @param  {} operationData An object containing the `pixelData` to
+ *                          modify, the `segmentIndex` and the `points` array.
+ * @returns {null}
+ */
+export function fillOutsideFreehand(evt, operationData) {
+  fillFreehand(evt, operationData, false);
+}

--- a/imaging/tools/strategies/index.js
+++ b/imaging/tools/strategies/index.js
@@ -1,0 +1,2 @@
+export { eraseInsideFreehand, eraseOutsideFreehand } from "./eraseFreehand";
+export { fillInsideFreehand, fillOutsideFreehand } from "./fillFreehand";

--- a/imaging/tools/tools.default.js
+++ b/imaging/tools/tools.default.js
@@ -8,14 +8,19 @@
  *      viewports : "all" or [array of target viewports],
  *      configuration : configuration {object},
  *      options : options {object},
- *      class : cornerstone tool library class name (ie "LengthTool" for Length tool)
- *      sync : cornerstone synchronizer name (ie "wwwcSynchronizer" for Wwwc sync tool)
+ *      class : cornerstone tool library class name (ie "LengthTool" for Length tool),
+ *      sync : cornerstone synchronizer name (ie "wwwcSynchronizer" for Wwwc sync tool),
+ *      cleanable : if true, this tool will be removed when calling "no tools",
+ *      defaultActive : if true, this tool will be activated when calling "addDefaultTools",
+ *      shortcut : keyboard shortcut [not implemented],
+ *      type : tool category inside Larvitar (one of: "utils", "annotation", "segmentation")
  * }
  *
  */
 
-import { filter } from "lodash";
+import { filter, isArray } from "lodash";
 import ThresholdsBrushTool from "./thresholdsBrushTool";
+import PolylineScissorsTool from "./polylineScissorsTool";
 
 /**
  * These tools are added with `addDefaultTools()`
@@ -30,7 +35,7 @@ const DEFAULT_TOOLS = {
       supportedInteractionTypes: ["Mouse", "Touch"]
     },
     cleanable: false,
-    defaultActive: false,
+    defaultActive: true,
     class: "WwwcTool",
     sync: "wwwcSynchronizer",
     description: "Change image contrast",
@@ -301,6 +306,28 @@ const DEFAULT_TOOLS = {
     description: "A circular segmentation tool",
     shortcut: "ctrl-r",
     type: "segmentation"
+  },
+  CorrectionScissors: {
+    name: "CorrectionScissors",
+    viewports: "all",
+    configuration: {},
+    options: { mouseButtonMask: 1 },
+    cleanable: true,
+    class: "CorrectionScissorsTool",
+    description: "A correction segmentation tool",
+    shortcut: "ctrl-p",
+    type: "segmentation"
+  },
+  PolylineScissors: {
+    name: "PolylineScissors",
+    viewports: "all",
+    configuration: {},
+    options: { mouseButtonMask: 1 },
+    cleanable: true,
+    class: "PolylineScissorsTool",
+    description: "A polyline segmentation tool",
+    shortcut: "ctrl-s",
+    type: "segmentation"
   }
 };
 
@@ -308,7 +335,8 @@ const DEFAULT_TOOLS = {
  * D/Vision Lab custom tools
  */
 const dvTools = {
-  ThresholdsBrushTool: ThresholdsBrushTool
+  ThresholdsBrushTool: ThresholdsBrushTool,
+  PolylineScissorsTool: PolylineScissorsTool
 };
 
 /**
@@ -319,4 +347,25 @@ const getDefaultToolsByType = function (type) {
   return filter(DEFAULT_TOOLS, ["type", type]);
 };
 
-export { DEFAULT_TOOLS, getDefaultToolsByType, dvTools };
+/**
+ * Override default tools props
+ * @param {Array} newProps - An array of objects as in the DEFAULT_TOOLS list, but with a subset of props
+ * NOTE: prop "name" is mandatory
+ */
+const setDefaultToolsProps = function (newProps) {
+  if (isArray(newProps)) {
+    newProps.forEach(props => {
+      let targetTool = DEFAULT_TOOLS[props.name];
+      if (targetTool) {
+        DEFAULT_TOOLS[props.name] = Object.assign(targetTool, props);
+      } else {
+        console.error(`${newProps.name} does not exist`);
+      }
+    });
+  } else {
+    console.error("newProps must be an array");
+  }
+  console.log(DEFAULT_TOOLS);
+};
+
+export { DEFAULT_TOOLS, dvTools, getDefaultToolsByType, setDefaultToolsProps };

--- a/index.js
+++ b/index.js
@@ -95,7 +95,8 @@ import {
 
 import {
   DEFAULT_TOOLS,
-  getDefaultToolsByType
+  getDefaultToolsByType,
+  setDefaultToolsProps
 } from "./imaging/tools/tools.default";
 
 import {
@@ -251,5 +252,6 @@ export {
   loadAnnotations,
   exportAnnotations,
   setSegmentationConfig,
-  csToolsUpdateImageIndex
+  csToolsUpdateImageIndex,
+  setDefaultToolsProps
 };


### PR DESCRIPTION
Ho aggiunto un nuovo mixin per gestire l'interazione della polyline, purtroppo ho dovuto copiare un paio di file delle "strategies" perchè non sono esposte dai cs tools. 
Già che c'ero ho aggiunto una funzione per modificare le props dei default tools prima di aggiungerli. 
Ho fatto un esempio sfruttando entrambe le modifiche. 

Close #29 