### PR TITLE
Cache fixes

### DIFF
--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -133,7 +133,8 @@
           console.log(serie);
           larvitar.renderImage(serie, "viewer");
           // optionally cache the series
-          larvitar.populateLarvitarManager(seriesId, serie, function(resp) {
+          larvitar.populateLarvitarManager(seriesId, serie);
+          larvitar.cacheImages(seriesId, serie, function (resp) {
             console.log(resp.loading);
             console.log(resp.series);
           });

--- a/imaging/image_rendering.js
+++ b/imaging/image_rendering.js
@@ -69,6 +69,8 @@ export function loadAndCacheImages(series, callback) {
   callback(response);
   // add serie's imageIds into store
   larvitar_store.addSeriesIds(series.seriesUID, series.imageIds);
+  // add serie's caching progress into store
+  larvitar_store.set("progress", [series.seriesUID, 0]);
   each(series.imageIds, function (imageId) {
     cornerstone.loadAndCacheImage(imageId).then(function (image) {
       series.instances[imageId].pixelData = image.getPixelData();
@@ -77,6 +79,7 @@ export function loadAndCacheImages(series, callback) {
         (cachingCounter / series.imageIds.length) * 100
       );
       response.loading = cachingPercentage;
+      larvitar_store.set("progress", [series.seriesUID, cachingPercentage]);
       if (cachingCounter == series.imageIds.length) {
         let t1 = performance.now();
         console.log(`Call to cacheImages took ${t1 - t0} milliseconds.`);

--- a/imaging/image_store.js
+++ b/imaging/image_store.js
@@ -65,7 +65,7 @@ class Larvitar_Store {
     this.vuex_module = vuex_module;
     this.state = {
       manager: null,
-      series: {}, // seriesUID: [imageIds]
+      series: {}, // seriesUID: {imageIds:[], progress:value}
       leftMouseHandler: "Wwwc",
       colormapId: "gray",
       viewports: {},
@@ -144,7 +144,10 @@ class Larvitar_Store {
         : dispatch;
       this.vuex_store.dispatch(route, seriesId, imageIds);
     } else {
-      this.state.series[seriesId] = imageIds;
+      if (this.state.series[seriesId] == null) {
+        this.state.series[seriesId] = {};
+      }
+      this.state.series[seriesId]["imageIds"] = imageIds;
     }
   }
 
@@ -219,6 +222,8 @@ class Larvitar_Store {
           data[5];
         this.state["viewports"][data[0]]["default"]["voi"]["windowCenter"] =
           data[6];
+      } else if (field == "progress") {
+        this.state.series[data[0]]["progress"] = data[1];
       } else if (field == "manager") {
         this.state.manager = data;
       } else {

--- a/imaging/image_utils.js
+++ b/imaging/image_utils.js
@@ -19,7 +19,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 
 // internal libraries
-import { getCustomImageId } from "./loaders/commonLoader";
+import { getDicomImageId } from "./loaders/dicomLoader";
 import TAG_DICT from "./dataDictionary.json";
 
 // global module variables
@@ -332,7 +332,7 @@ export const getReslicedMetadata = function (
   let reslicedIOP = getReslicedIOP(sampleMetadata.x00200037, permuteTable);
 
   for (let f = 0; f < toSize[2]; f++) {
-    let reslicedImageId = getCustomImageId(imageLoaderName);
+    let reslicedImageId = getDicomImageId(imageLoaderName);
     reslicedImageIds.push(reslicedImageId);
 
     let instanceId = uuidv4();
@@ -438,7 +438,7 @@ export const getCmprMetadata = function (
   let reslicedInstances = {};
 
   for (let f = 0; f < header.frames_number; f++) {
-    let reslicedImageId = getCustomImageId(imageLoaderName);
+    let reslicedImageId = getDicomImageId(imageLoaderName);
     reslicedImageIds.push(reslicedImageId);
 
     let instanceId = uuidv4();

--- a/imaging/loaders/commonLoader.js
+++ b/imaging/loaders/commonLoader.js
@@ -5,6 +5,7 @@
 
 // external libraries
 import cornerstoneWADOImageLoader from "cornerstone-wado-image-loader";
+import { omit } from "lodash";
 
 // internal libraries
 import { getNrrdImageId } from "./nrrdLoader";

--- a/imaging/loaders/commonLoader.js
+++ b/imaging/loaders/commonLoader.js
@@ -7,25 +7,34 @@
 import cornerstoneWADOImageLoader from "cornerstone-wado-image-loader";
 import { omit } from "lodash";
 
-// internal libraries
-import { getNrrdImageId } from "./nrrdLoader";
-import { getDicomImageId } from "./dicomLoader";
-import { getMultiFrameImageId } from "./multiframeLoader";
-
 // global variables
 var larvitarManager = {};
 var imageTracker = {};
 
 /*
  * This module provides the following functions to be exported:
+ * populateLarvitarManager(seriesId, seriesData)
  * getLarvitarManager()
  * getLarvitarImageTracker()
  * resetLarvitarManager()
  * removeSeriesFromLarvitarManager(seriesId)
  * getSeriesDataFromLarvitarManager(seriesId)
- * getCustomImageId(loaderName)
  * getImageFrame(metadata, dataSet)
  */
+
+/**
+ * This function can be called in order to populate the Larvitar manager
+ * @instance
+ * @function populateLarvitarManager
+ * @param {String} seriesId The Id of the series
+ * @param {Object} seriesData The series data
+ * @returns {manager} the Larvitar manager
+ */
+export const populateLarvitarManager = function (seriesId, seriesData) {
+  let manager = getLarvitarManager();
+  manager[seriesId] = seriesData;
+  return manager;
+};
 
 /**
  * Return the common data loader manager
@@ -78,35 +87,6 @@ export const removeSeriesFromLarvitarManager = function (seriesId) {
  */
 export const getSeriesDataFromLarvitarManager = function (seriesId) {
   return larvitarManager[seriesId];
-};
-
-/**
- * Generate a custom ImageId from loader name
- * @instance
- * @function getCustomImageId
- * @param {String} loaderName The name of the current loader
- * @returns {String} custom Image Id
- */
-export const getCustomImageId = function (loaderName) {
-  let imageId;
-  switch (loaderName) {
-    case "dicomLoader":
-      imageId = getDicomImageId(loaderName);
-      break;
-    case "resliceLoader":
-      imageId = getDicomImageId(loaderName);
-      break;
-    case "nrrdLoader":
-      imageId = getNrrdImageId(loaderName);
-      break;
-    case "multiFrameLoader":
-      imageId = getMultiFrameImageId(loaderName);
-      break;
-    default:
-      console.warn("no matching loader");
-      imageId = null;
-  }
-  return imageId;
 };
 
 /**

--- a/imaging/loaders/dicomLoader.js
+++ b/imaging/loaders/dicomLoader.js
@@ -12,35 +12,27 @@ import { getLarvitarManager } from "./commonLoader";
 
 /*
  * This module provides the following functions to be exported:
- * populateLarvitarManager(seriesId, seriesData, callback)
+ * cacheImages(seriesId, seriesData, callback)
  * getDicomImageId(dicomLoaderName)
  */
 
 let imageLoaderCounter = 0;
 
 /**
- * This function can be called in order to populate the DICOM manager for a provided orientation
+ * Load and cache images and then store in manager if ready
  * @instance
- * @function populateLarvitarManager
+ * @function cacheImages
  * @param {String} seriesId The Id of the series
  * @param {Object} seriesData The series data
  * @param {Function} callback An optional callback function
  */
-export const populateLarvitarManager = function (
-  seriesId,
-  seriesData,
-  callback
-) {
+export const cacheImages = function (seriesId, seriesData, callback) {
   let manager = getLarvitarManager();
-
-  // check if DICOM Manager exists for this seriesId
-  if (!manager[seriesId]) {
-    manager[seriesId] = {};
-  }
-  manager[seriesId] = seriesData;
   loadAndCacheImages(seriesData, function (resp) {
     if (resp.loading == 100) {
-      manager[seriesId] = resp.series; // TODO Metto via prima della cache o faccio due funz separate
+      if (manager[seriesId]) {
+        manager[seriesId] = resp.series;
+      }
       imageLoaderCounter += seriesData.imageIds.length;
     }
     if (callback) {

--- a/imaging/loaders/dicomLoader.js
+++ b/imaging/loaders/dicomLoader.js
@@ -37,9 +37,10 @@ export const populateLarvitarManager = function (
   if (!manager[seriesId]) {
     manager[seriesId] = {};
   }
+  manager[seriesId] = seriesData;
   loadAndCacheImages(seriesData, function (resp) {
     if (resp.loading == 100) {
-      manager[seriesId] = resp.series;
+      manager[seriesId] = resp.series; // TODO Metto via prima della cache o faccio due funz separate
       imageLoaderCounter += seriesData.imageIds.length;
     }
     if (callback) {

--- a/imaging/loaders/nrrdLoader.js
+++ b/imaging/loaders/nrrdLoader.js
@@ -6,7 +6,7 @@
 // external libraries
 import cornerstone from "cornerstone-core";
 import cornerstoneWADOImageLoader from "cornerstone-wado-image-loader";
-import { each, clone, omit, range, findKey, filter, pickBy } from "lodash";
+import { each, clone, range, findKey, filter, pickBy } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 // internal libraries

--- a/index.js
+++ b/index.js
@@ -111,12 +111,12 @@ import {
 } from "./imaging/tools/tools.default";
 
 import {
+  populateLarvitarManager,
   getLarvitarManager,
   getLarvitarImageTracker,
   resetLarvitarManager,
   removeSeriesFromLarvitarManager,
   getSeriesDataFromLarvitarManager,
-  getCustomImageId,
   getImageFrame
 } from "./imaging/loaders/commonLoader";
 
@@ -129,10 +129,7 @@ import {
   getNrrdSerieDimensions
 } from "./imaging/loaders/nrrdLoader";
 
-import {
-  populateLarvitarManager,
-  getDicomImageId
-} from "./imaging/loaders/dicomLoader";
+import { getDicomImageId, cacheImages } from "./imaging/loaders/dicomLoader";
 
 import { loadReslicedImage } from "./imaging/loaders/resliceLoader";
 
@@ -233,12 +230,12 @@ export {
   // image_contours
   parseContours,
   // loaders/commonLoader
+  populateLarvitarManager,
   getLarvitarManager,
   getLarvitarImageTracker,
   resetLarvitarManager,
   removeSeriesFromLarvitarManager,
   getSeriesDataFromLarvitarManager,
-  getCustomImageId,
   getImageFrame,
   // loaders/nrrdLoader
   buildNrrdImage,
@@ -250,8 +247,8 @@ export {
   // loaders/resliceLoader
   loadReslicedImage,
   // loaders/dicomLoader
-  populateLarvitarManager,
   getDicomImageId,
+  cacheImages,
   // loaders/multiFrameLoader
   loadMultiFrameImage,
   buildMultiFrameImage,

--- a/modules/vuex/larvitar.js
+++ b/modules/vuex/larvitar.js
@@ -64,6 +64,9 @@ export default {
     }
   },
   actions: {
+    // TODO SERIES OBJ NOW IS SERIES: {imageIds: [], progress: value}
+    // UPDATE ADD SERIESIDS
+    // ADD setProgress(seriesId, value)
     addSeriesIds: ({ state }, { imageIds, seriesId }) =>
       Vue.set(state.series, seriesId, imageIds),
     addViewport: ({ state }, viewportId) => {


### PR DESCRIPTION
- to populate the manager simply use sync and real time function populateLarvitarManager
- to cache images and update manager with cached pixeldata use cacheImages
- cacheimages returns progress in callback and save progress into store.state.series[seriesId]["progress"]

TODO:
- Fix VueX store (addSeriesIds) and setProgress function

See base.html for a live example