### PR TITLE
build data async

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ import {
   buildVolume,
   buildHeader,
   buildData,
+  buildDataAsync,
   importNRRDImage
 } from "./imaging/image_io";
 
@@ -191,6 +192,7 @@ export {
   buildVolume,
   buildHeader,
   buildData,
+  buildDataAsync,
   importNRRDImage,
   // image_layers
   getMainLayer,


### PR DESCRIPTION
Implemented async version of buildData: it does not block the js interpreter (UI spinner continue running etc...)
Use this in dicom.vision and doors