### PR TITLE
fix: set in store

### DIFF
--- a/imaging/image_store.js
+++ b/imaging/image_store.js
@@ -229,10 +229,10 @@ class Larvitar_Store {
       } else if (field == "manager") {
         this.state.manager = data;
       } else {
-        if (data.length == 0) {
-          this.state[field] = data;
+        if (Array.isArray(data)) {
+          this.state[field][data[0]] = data[1];
         } else {
-          this.state[data[0]][field] = data[1];
+          this.state[field] = data;
         }
       }
     }


### PR DESCRIPTION
fix #111 

In any case, you need to set the active tool in larvitar store using:
`larvitar_store.set("leftMouseHandler", <TOOLNAME>);`

or for vuex

`store.dispatch("larvitar/setLeftMouseHandler",  <TOOLNAME>);`