### PR TITLE
Issue#129 memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Dicom Image Toolkit for CornestoneJS
 
-### Current version: 0.13.0
+### Current version: 0.13.1
 
-### Latest Stable version: 0.13.0
+### Latest Stable version: 0.13.1
 
 ### Latest Published Release: 0.13.0
 

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -61,7 +61,6 @@
             }
 
             function renderSerie() {
-              larvitar.resetImageParsing();
               larvitar.resetLarvitarManager();
               larvitar.readFiles(demoFiles, function (seriesStack, err) {
                 if (seriesStack) {
@@ -135,7 +134,6 @@
       }
 
       function renderSerie() {
-        larvitar.resetImageParsing();
         larvitar.resetLarvitarManager();
         larvitar.readFiles(demoFiles, function (seriesStack, err) {
           if (seriesStack) {

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -62,28 +62,34 @@
 
             function renderSerie() {
               larvitar.resetImageParsing();
+              larvitar.resetLarvitarManager();
               larvitar.readFiles(demoFiles, function (seriesStack, err) {
-                // render the first series of the study
-                let seriesId = _.keys(seriesStack)[0];
-                let serie = seriesStack[seriesId];
-                console.log(serie);
-                larvitar.renderImage(serie, "viewer");
-                // optionally cache the series
-                larvitar.populateLarvitarManager(seriesId, serie);
-                larvitar.cacheImages(serie, function (resp) {
-                  if (resp.loading == 100) {
-                    let cache =  larvitar.cornerstone.imageCache;
-                    console.log("Cache size: ",
-                    cache.getCacheInfo().cacheSizeInBytes / 1e6, "Mb")
-                  }
-                });
-                larvitar.addDefaultTools();
-                larvitar.setToolActive(
-                  larvitar.larvitar_store.state.leftMouseHandler
-                );
+                if (seriesStack) {
+                  // render the first series of the study
+                  let seriesId = _.keys(seriesStack)[0];
+                  let serie = seriesStack[seriesId];
+                  larvitar.renderImage(serie, "viewer");
+                  // optionally cache the series
+                  larvitar.populateLarvitarManager(seriesId, serie);
+                  larvitar.cacheImages(serie, function (resp) {
+                    if (resp.loading == 100) {
+                      let cache = larvitar.cornerstone.imageCache;
+                      console.log(
+                        "Cache size: ",
+                        cache.getCacheInfo().cacheSizeInBytes / 1e6,
+                        "Mb"
+                      );
+                    }
+                  });
+                  larvitar.addDefaultTools();
+                  larvitar.setToolActive(
+                    larvitar.larvitar_store.state.leftMouseHandler
+                  );
+                } else {
+                  console.log(err);
+                }
               });
             }
-
             let demoFileList = getDemoFileNames();
 
             _.each(demoFileList, function (demoFile) {
@@ -132,26 +138,30 @@
         larvitar.resetImageParsing();
         larvitar.resetLarvitarManager();
         larvitar.readFiles(demoFiles, function (seriesStack, err) {
-          // render the first series of the study
-          let seriesId = _.keys(seriesStack)[0];
-          let serie = seriesStack[seriesId];
-          larvitar.renderImage(serie, "viewer");
-          // optionally cache the series
-          larvitar.populateLarvitarManager(seriesId, serie);
-          larvitar.cacheImages(serie, function (resp) {
-            if (resp.loading == 100) {
-              let cache = larvitar.cornerstone.imageCache;
-              console.log(
-                "Cache size: ",
-                cache.getCacheInfo().cacheSizeInBytes / 1e6,
-                "Mb"
-              );
-            }
-          });
-          larvitar.addDefaultTools();
-          larvitar.setToolActive(
-            larvitar.larvitar_store.state.leftMouseHandler
-          );
+          if (seriesStack) {
+            // render the first series of the study
+            let seriesId = _.keys(seriesStack)[0];
+            let serie = seriesStack[seriesId];
+            larvitar.renderImage(serie, "viewer");
+            // optionally cache the series
+            larvitar.populateLarvitarManager(seriesId, serie);
+            larvitar.cacheImages(serie, function (resp) {
+              if (resp.loading == 100) {
+                let cache = larvitar.cornerstone.imageCache;
+                console.log(
+                  "Cache size: ",
+                  cache.getCacheInfo().cacheSizeInBytes / 1e6,
+                  "Mb"
+                );
+              }
+            });
+            larvitar.addDefaultTools();
+            larvitar.setToolActive(
+              larvitar.larvitar_store.state.leftMouseHandler
+            );
+          } else {
+            console.log(err);
+          }
         });
       }
       let demoFileList = getDemoFileNames();

--- a/docs/examples/colorMaps.html
+++ b/docs/examples/colorMaps.html
@@ -67,7 +67,6 @@
             }
 
             function renderSerie() {
-              larvitar.resetImageParsing();
               larvitar.readFiles(demoFiles, function (seriesStack, err) {
                 // render the first series of the study
                 let seriesId = _.keys(seriesStack)[0];
@@ -142,7 +141,6 @@
       }
 
       function renderSerie() {
-        larvitar.resetImageParsing();
         larvitar.readFiles(demoFiles, function (seriesStack, err) {
           // render the first series of the study
           let seriesId = _.keys(seriesStack)[0];

--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -64,7 +64,6 @@
             }
 
             function renderSerie() {
-              larvitar.resetImageParsing();
               larvitar.readFiles(demoFiles, function (seriesStack, err) {
                 let seriesId = _.keys(seriesStack)[0];
                 let serie = seriesStack[seriesId];
@@ -146,7 +145,6 @@
       }
 
       function renderSerie() {
-        larvitar.resetImageParsing();
         larvitar.readFiles(demoFiles, function (seriesStack, err) {
           let seriesId = _.keys(seriesStack)[0];
           let serie = seriesStack[seriesId];

--- a/docs/examples/layers.html
+++ b/docs/examples/layers.html
@@ -74,7 +74,6 @@
             let layer_1, layer_2;
 
             function renderSerie() {
-                larvitar.resetImageParsing();
                 larvitar.readFiles(demoFiles, function (seriesStack, err) {
                 let seriesId = _.keys(seriesStack)[0];
 
@@ -177,7 +176,6 @@
       let layer_1, layer_2;
 
       function renderSerie() {
-        larvitar.resetImageParsing();
         larvitar.readFiles(demoFiles, function (seriesStack, err) {
           let seriesId = _.keys(seriesStack)[0];
 

--- a/docs/examples/multiframe.html
+++ b/docs/examples/multiframe.html
@@ -52,7 +52,6 @@
               larvitar.larvitar_store.addViewport("viewer");
 
               function renderSerie() {
-                larvitar.resetImageParsing();
                 larvitar.readFiles(demoFiles, function (seriesStack, err) {
                   // render the first series of the study
                   let seriesId = _.keys(seriesStack)[0];
@@ -130,7 +129,6 @@
       larvitar.larvitar_store.addViewport("viewer");
 
       function renderSerie() {
-        larvitar.resetImageParsing();
         larvitar.readFiles(demoFiles, function (seriesStack, err) {
           // render the first series of the study
           let seriesId = _.keys(seriesStack)[0];

--- a/docs/examples/reslice.html
+++ b/docs/examples/reslice.html
@@ -69,7 +69,6 @@
               }
 
               function renderSerie() {
-                larvitar.resetImageParsing();
                 larvitar.readFiles(demoFiles, function (seriesStack, err) {
                   // render the first series of the study
                   let seriesId = _.keys(seriesStack)[0];
@@ -136,7 +135,6 @@
       }
 
       function renderSerie() {
-        larvitar.resetImageParsing();
         larvitar.readFiles(demoFiles, function (seriesStack, err) {
           // render the first series of the study
           let seriesId = _.keys(seriesStack)[0];

--- a/imaging/image_io.js
+++ b/imaging/image_io.js
@@ -131,7 +131,7 @@ export const buildData = function (series, useSeriesData) {
     console.log(`Call to buildData took ${t1 - t0} milliseconds.`);
     return data;
   } else {
-    return null;
+    throw new Error("Data has not been builded: not enough memory");
   }
 };
 
@@ -178,7 +178,7 @@ export const buildDataAsync = function (series, cb) {
     }
     runFillPixelData(data, cb);
   } else {
-    cb(null);
+    throw new Error("Data has not been builded: not enough memory");
   }
 };
 

--- a/imaging/image_loading.js
+++ b/imaging/image_loading.js
@@ -146,7 +146,8 @@ export const updateLoadedStack = function (seriesData, allSeriesStack) {
       numberOfFrames: numberOfFrames,
       isMultiframe: isMultiframe,
       modality: modality,
-      color: color
+      color: color,
+      bytes: 0
     };
   }
 
@@ -161,6 +162,7 @@ export const updateLoadedStack = function (seriesData, allSeriesStack) {
 
     allSeriesStack[sid].imageIds.push(imageId);
     allSeriesStack[sid].numberOfImages += 1;
+    allSeriesStack[sid].bytes += seriesData.file.size;
     // store needed instance tags
     allSeriesStack[sid].instances[imageId] = {
       metadata: seriesData.metadata,

--- a/imaging/image_parsing.js
+++ b/imaging/image_parsing.js
@@ -16,6 +16,7 @@ import {
   parseTag
 } from "./image_utils.js";
 import { updateLoadedStack } from "./image_loading.js";
+import { checkMemoryAllocation } from "./monitors/memory.js";
 
 // global module variables
 var parsingQueueFlag = null;
@@ -192,6 +193,11 @@ let dumpFiles = function (fileList, callback) {
  * @param {Function} callback - called with (imageObject, errorString)
  */
 let dumpFile = function (file, callback) {
+  // Check if there is enough memory to dump the file
+  if (checkMemoryAllocation(file.size) === false) {
+    callback(null, "Available memory is not enough");
+  }
+
   let reader = new FileReader();
   reader.onload = function () {
     let arrayBuffer = reader.result;
@@ -247,9 +253,8 @@ let dumpFile = function (file, callback) {
           imageObject.metadata.patientBirthdate = metadata["x00100030"];
           imageObject.metadata.seriesDescription = metadata["x0008103e"];
           imageObject.metadata.seriesDate = metadata["x00080021"];
-          imageObject.metadata.seriesModality = metadata[
-            "x00080060"
-          ].toLowerCase();
+          imageObject.metadata.seriesModality =
+            metadata["x00080060"].toLowerCase();
           imageObject.metadata.intercept = metadata["x00281052"];
           imageObject.metadata.slope = metadata["x00281053"];
           imageObject.metadata.pixelSpacing = pixelSpacing;

--- a/imaging/loaders/commonLoader.js
+++ b/imaging/loaders/commonLoader.js
@@ -9,6 +9,7 @@ import { omit } from "lodash";
 
 // internal libraries
 import { buildMultiFrameImage } from "./multiframeLoader";
+import { checkMemoryAllocation } from "../monitors/memory";
 
 // global variables
 var larvitarManager = {};
@@ -35,10 +36,12 @@ var imageTracker = {};
  */
 export const populateLarvitarManager = function (seriesId, seriesData) {
   let manager = getLarvitarManager();
-  if (seriesData.isMultiframe) {
-    buildMultiFrameImage(seriesId, seriesData);
-  } else {
-    manager[seriesId] = seriesData;
+  if (checkMemoryAllocation(seriesData.bytes)) {
+    if (seriesData.isMultiframe) {
+      buildMultiFrameImage(seriesId, seriesData);
+    } else {
+      manager[seriesId] = seriesData;
+    }
   }
   return manager;
 };
@@ -108,9 +111,8 @@ export const getImageFrame = function (metadata, dataSet) {
   let imagePixelModule;
 
   if (dataSet) {
-    imagePixelModule = cornerstoneWADOImageLoader.wadouri.metaData.getImagePixelModule(
-      dataSet
-    );
+    imagePixelModule =
+      cornerstoneWADOImageLoader.wadouri.metaData.getImagePixelModule(dataSet);
   } else {
     imagePixelModule = {
       samplesPerPixel: metadata.x00280002,

--- a/imaging/loaders/commonLoader.js
+++ b/imaging/loaders/commonLoader.js
@@ -32,7 +32,7 @@ var imageTracker = {};
  * @function populateLarvitarManager
  * @param {String} seriesId The Id of the series
  * @param {Object} seriesData The series data
- * @returns {manager} the Larvitar manager
+ * @returns {manager} the Larvitar manager or null if memory is not enough
  */
 export const populateLarvitarManager = function (seriesId, seriesData) {
   let manager = getLarvitarManager();
@@ -42,8 +42,10 @@ export const populateLarvitarManager = function (seriesId, seriesData) {
     } else {
       manager[seriesId] = seriesData;
     }
+    return manager;
+  } else {
+    return null;
   }
-  return manager;
 };
 
 /**

--- a/imaging/loaders/commonLoader.js
+++ b/imaging/loaders/commonLoader.js
@@ -35,8 +35,8 @@ var imageTracker = {};
  * @returns {manager} the Larvitar manager or null if memory is not enough
  */
 export const populateLarvitarManager = function (seriesId, seriesData) {
-  let manager = getLarvitarManager();
   if (checkMemoryAllocation(seriesData.bytes)) {
+    let manager = getLarvitarManager();
     if (seriesData.isMultiframe) {
       buildMultiFrameImage(seriesId, seriesData);
     } else {
@@ -44,7 +44,9 @@ export const populateLarvitarManager = function (seriesId, seriesData) {
     }
     return manager;
   } else {
-    return null;
+    throw new Error(
+      "Larvitar Manager has not been populated: not enough memory"
+    );
   }
 };
 

--- a/imaging/loaders/commonLoader.js
+++ b/imaging/loaders/commonLoader.js
@@ -32,7 +32,7 @@ var imageTracker = {};
  * @function populateLarvitarManager
  * @param {String} seriesId The Id of the series
  * @param {Object} seriesData The series data
- * @returns {manager} the Larvitar manager or null if memory is not enough
+ * @returns {manager} the Larvitar manager
  */
 export const populateLarvitarManager = function (seriesId, seriesData) {
   if (checkMemoryAllocation(seriesData.bytes)) {

--- a/imaging/loaders/multiframeLoader.js
+++ b/imaging/loaders/multiframeLoader.js
@@ -99,6 +99,7 @@ export const buildMultiFrameImage = function (seriesId, serie) {
       manager[seriesId].frameTime = frameTime;
       manager[seriesId].frameDelay = frameDelay;
       manager[seriesId].numberOfImages = undefined;
+      manager[seriesId].bytes = serie.bytes;
       manager[seriesId].imageIds.push(frameImageId);
       manager[seriesId].instances[frameImageId] = {
         instanceId: instanceId,
@@ -237,10 +238,11 @@ let createCustomImage = function (id, imageId, frameIndex, metadata) {
       };
 
       // convert color space if not isJPEGBaseline8BitColor
-      let isJPEGBaseline8BitColor = cornerstoneWADOImageLoader.isJPEGBaseline8BitColor(
-        imageFrame,
-        transferSyntax
-      );
+      let isJPEGBaseline8BitColor =
+        cornerstoneWADOImageLoader.isJPEGBaseline8BitColor(
+          imageFrame,
+          transferSyntax
+        );
 
       if (image.color && !isJPEGBaseline8BitColor) {
         // setup the canvas context

--- a/imaging/monitors/memory.js
+++ b/imaging/monitors/memory.js
@@ -1,0 +1,93 @@
+/** @module monitors/memory
+ *  @desc This file provides utility functions for
+ *        monitoring memory usage
+ */
+
+// external libraries
+import cornerstone from "cornerstone-core";
+
+// internal libraries
+
+// global module variables
+const backingMemory = 300 * 1048576; // 300 MB
+
+/*
+ * This module provides the following functions to be exported:
+ * checkMemoryAllocation()
+ * getUsedMemory()
+ * getAvailableMemory()
+ */
+
+/**
+ * Check memory allocation and returns false if js Heap size has reached its limit
+ * @instance
+ * @function checkMemoryAllocation
+ * @return {Boolean} - Returns a boolean flag to warn the user about memory allocation limit
+ */
+export const checkMemoryAllocation = function (bytes) {
+  if (checkMemorySupport()) {
+    let usedMemory = getUsedMemory();
+    let availableMemory = getAvailableMemory();
+    let isEnough = availableMemory - bytes - usedMemory > 0 ? true : false;
+    if (!isEnough) {
+      console.log("Total Memory Available is: ", getMB(availableMemory), " MB");
+      console.log("Currently Used Memory is: ", getMB(usedMemory), " MB");
+      console.log(
+        "New memory requested allocation is: ",
+        getMB(usedMemory + bytes),
+        " MB"
+      );
+    }
+    return isEnough;
+  } else {
+    console.warn("Check Memory Allocation is not supported");
+    return true;
+  }
+};
+
+/**
+ * Check performance.memory browser support and returns used Js Heap Size in Mb
+ * @instance
+ * @function getUsedMemory
+ * @return {Number} - Returns used JSHeapSize in bytes or NaN if not supported
+ */
+export const getUsedMemory = function () {
+  return checkMemorySupport() ? performance.memory.usedJSHeapSize : NaN;
+};
+
+/**
+ * Check performance.memory browser support and returns available Js Heap Size in Mb
+ * @instance
+ * @function getAvailableMemory
+ * @return {Number} - Returns available JSHeapSize in bytes or NaN if not supported
+ */
+export const getAvailableMemory = function () {
+  return checkMemorySupport()
+    ? performance.memory.jsHeapSizeLimit - backingMemory
+    : NaN;
+};
+
+/* Internal module functions */
+
+/**
+ * Check Browser support.
+ * Firefox and Safari are not supported
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory
+ * @instance
+ * @function checkMemorySupport
+ * @return {Boolean} - Returns memory object or false if not supported
+ */
+const checkMemorySupport = function () {
+  return performance.memory ? performance.memory : false;
+};
+
+/**
+ * Check Browser support.
+ * @instance
+ * @function getMB
+ * @param {Number} bytes - Memory in bytes
+ * @return {Number} - Memory in MB
+ */
+const getMB = function (bytes) {
+  return bytes / 1048576;
+};

--- a/imaging/monitors/memory.js
+++ b/imaging/monitors/memory.js
@@ -3,11 +3,6 @@
  *        monitoring memory usage
  */
 
-// external libraries
-import cornerstone from "cornerstone-core";
-
-// internal libraries
-
 // global module variables
 const backingMemory = 300 * 1048576; // 300 MB
 

--- a/index.js
+++ b/index.js
@@ -57,11 +57,7 @@ import {
   updateLoadedStack
 } from "./imaging/image_loading";
 
-import {
-  resetImageParsing,
-  readFiles,
-  dumpDataSet
-} from "./imaging/image_parsing";
+import { readFiles, dumpDataSet } from "./imaging/image_parsing";
 
 import {
   clearImageCache,
@@ -222,7 +218,6 @@ export {
   registerMultiFrameImageLoader,
   updateLoadedStack,
   // image_parsing
-  resetImageParsing,
   readFiles,
   dumpDataSet,
   // image_rendering

--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 import cornerstone from "cornerstone-core";
 import cornerstoneTools from "cornerstone-tools";
+
+import {
+  checkMemoryAllocation,
+  getUsedMemory,
+  getAvailableMemory
+} from "./imaging/monitors/memory";
+
 import { initLarvitarStore, larvitar_store } from "./imaging/image_store";
 
 import { parseContours } from "./imaging/image_contours";
@@ -171,6 +178,10 @@ export {
   // global cornerstone variables
   cornerstone,
   cornerstoneTools,
+  // memory module
+  checkMemoryAllocation,
+  getUsedMemory,
+  getAvailableMemory,
   // larvitar store
   initLarvitarStore,
   larvitar_store,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dicom",
     "imaging"
   ],
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "javascript library for loading, rendering and interact with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
I've added some functionalities to monitor memory usage with [performance.memory ](https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory).

Unfortunately it currently support only Chrome, Edge and Opera.

Here's how to use it:

- `populateLarvitarManager` returns the `manager `or `throw` an **error** (`throw new Error( "Larvitar Manager has not been populated: not enough memory");`) if **memory is not enough**
- `readFiles `returns a `callback `with the **parsed stack** and **error message**. If there's an _error_ (eg not enough memory), the **parsed stack** is `null`
- `buildData `and `buildDataAsync `return the **typed array** or `throw `an **error** (`throw new Error("Data has not been builded: not enough memory");`)  if there's **not enough memory** to build the _contiguous array_