### PR TITLE
fix: reset memory after parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Dicom Image Toolkit for CornestoneJS
 
-### Current version: 0.13.3
+### Current version: 0.13.4
 
-### Latest Stable version: 0.13.3
+### Latest Stable version: 0.13.4
 
-### Latest Published Release: 0.13.3
+### Latest Published Release: 0.13.4
 
 This library provides common dicom functionalities to be used in web-applications. Multiplanar reformat on axial, sagittal and coronal viewports is included as well as custom loader/exporter for nrrd files and orthogonal reslice.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dicom",
     "imaging"
   ],
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "javascript library for loading, rendering and interact with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
Reset typed array and file object inside allSeriesStack object before setting it to null on memory errors.
This strategy allows gc to correctly deallocate arrays.