### PR TITLE
fix: wadoimageloader clean cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Dicom Image Toolkit for CornestoneJS
 
-### Current version: 0.13.4
+### Current version: 0.13.5
 
-### Latest Stable version: 0.13.4
+### Latest Stable version: 0.13.5
 
-### Latest Published Release: 0.13.4
+### Latest Published Release: 0.13.5
 
 This library provides common dicom functionalities to be used in web-applications. Multiplanar reformat on axial, sagittal and coronal viewports is included as well as custom loader/exporter for nrrd files and orthogonal reslice.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
           <div class="col-6 text-center">
             <div id="title">
               <p class="lead">Dicom Image Toolkit for CornestoneJS</p>
-              <p class="lead"><i>v0.13.0</i></p>
+              <p class="lead"><i>v0.13.5</i></p>
             </div>
           </div>
           <div class="col-3"></div>

--- a/imaging/image_io.js
+++ b/imaging/image_io.js
@@ -57,8 +57,8 @@ export const buildHeader = function (series) {
   );
 
   header.volume.pixelSpacing = getMeanValue(series, "pixelSpacing", true);
-  header.volume.maxPixelValue = getMeanValue(series, "maxPixelValue", false);
-  header.volume.minPixelValue = getMeanValue(series, "minPixelValue", false);
+  // header.volume.maxPixelValue = getMeanValue(series, "maxPixelValue", false);
+  // header.volume.minPixelValue = getMeanValue(series, "minPixelValue", false);
   header.volume.sliceThickness = getDistanceBetweenSlices(series, 0, 1);
 
   forEach(series.imageIds, function (imageId) {

--- a/imaging/image_rendering.js
+++ b/imaging/image_rendering.js
@@ -252,6 +252,12 @@ export const renderImage = function (seriesStack, elementId, defaultProps) {
 
   let series = { ...seriesStack };
 
+  let seriesInStore = larvitar_store.get("series");
+
+  if (!has(seriesInStore, series.seriesUID)) {
+    larvitar_store.addSeriesIds(series.seriesUID, series.imageIds);
+  }
+
   // default to 0 if multiframe and frameId is null
   let frameId = series.isMultiframe ? 1 : null;
 
@@ -322,10 +328,12 @@ export const renderImage = function (seriesStack, elementId, defaultProps) {
     larvitar_store.set("renderingStatus", [elementId, true]);
     let t1 = performance.now();
     console.log(`Call to renderImage took ${t1 - t0} milliseconds.`);
+
+    let uri = cornerstoneWADOImageLoader.wadouri.parseImageId(data.imageId).url;
+    cornerstoneWADOImageLoader.wadouri.dataSetCacheManager.unload(uri);
     image = null;
     series = null;
     data = null;
-    cornerstoneWADOImageLoader.wadouri.dataSetCacheManager.purge();
   });
 
   csToolsCreateStack(element, series.imageIds, data.imageIndex - 1);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dicom",
     "imaging"
   ],
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "javascript library for loading, rendering and interact with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
- clean single wado image loader uri instead of call purgecache (wrong)
- set seriesIds in store for decaching purpose
- commented useless lines in buildHeader

Always call `larvitar.cleanImageCache(seriesId)` when a canvas is destroyed , wado imageloader has its internal dataSetCache