### PR TITLE
Mouse handlers reworking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Dicom Image Toolkit for CornestoneJS
 
-### Current version: 0.14.0
+### Current version: 0.15.0
 
-### Latest Stable version: 0.14.0
+### Latest Stable version: 0.15.0
 
-### Latest Published Release: 0.14.0
+### Latest Published Release: 0.15.0
 
 This library provides common dicom functionalities to be used in web-applications. Multiplanar reformat on axial, sagittal and coronal viewports is included as well as custom loader/exporter for nrrd files and orthogonal reslice.
 

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -100,7 +100,7 @@
       </div>
     </div>
 
-    <script src="./larvitar.js"></script>
+    <script src="../../dist/larvitar.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
 
     <script>
@@ -121,6 +121,8 @@
       larvitar.initializeImageLoader();
       larvitar.initializeCSTools();
       larvitar.larvitar_store.addViewport("viewer");
+
+      window.larvitar_store = larvitar.larvitar_store;
 
       async function createFile(fileName, cb) {
         let response = await fetch("./demo/" + fileName);
@@ -154,9 +156,7 @@
               }
             });
             larvitar.addDefaultTools();
-            larvitar.setToolActive(
-              larvitar.larvitar_store.state.leftMouseHandler
-            );
+            larvitar.setToolActive("Wwwc");
           } else {
             console.log(err);
           }

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -100,7 +100,7 @@
       </div>
     </div>
 
-    <script src="../../dist/larvitar.js"></script>
+    <script src="./larvitar.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
 
     <script>
@@ -121,8 +121,6 @@
       larvitar.initializeImageLoader();
       larvitar.initializeCSTools();
       larvitar.larvitar_store.addViewport("viewer");
-
-      window.larvitar_store = larvitar.larvitar_store;
 
       async function createFile(fileName, cb) {
         let response = await fetch("./demo/" + fileName);

--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -163,8 +163,8 @@
               KEY_L: "Length"
             },
             mouse_button_right: {
-              ctrl: "Zoom",
-              default: "Wwwc"
+              ctrl: "Pan",
+              default: "Zoom"
             },
             debug: true
           };

--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -106,7 +106,7 @@
       </div>
     </div>
 
-    <script src="./larvitar.js"></script>
+    <script src="../../dist/larvitar.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
     <script
       src="https://code.jquery.com/jquery-3.6.0.slim.min.js"
@@ -132,7 +132,12 @@
       larvitar.initializeImageLoader();
       larvitar.initializeCSTools();
       larvitar.larvitar_store.addViewport("viewer");
-      larvitar.addMouseKeyHandlers(null, ["viewer"]);
+
+      // setInterval(() => {
+      //   console.log(larvitar.larvitar_store);
+      //   console.log(larvitar.larvitar_store.state.viewports.viewer.viewport);
+      // }, 1000);
+      window.larvitar_store = larvitar.larvitar_store;
 
       async function createFile(fileName, cb) {
         let response = await fetch("./demo/" + fileName);
@@ -154,8 +159,8 @@
 
           let mouseConfig = {
             keyboard_shortcuts: {
-              a: "Angle",
-              l: "Length"
+              KEY_A: "Angle",
+              KEY_L: "Length"
             },
             mouse_button_right: {
               ctrl: "Zoom",
@@ -164,7 +169,8 @@
             debug: true
           };
 
-          larvitar.addMouseKeyHandlers(mouseConfig);
+          // NOTE: this also activate the tools marked as default for each mouse button
+          larvitar.addMouseKeyHandlers(mouseConfig, ["viewer"]);
         });
       }
 
@@ -176,7 +182,7 @@
       let tool_counter = 0;
       document.onkeypress = function (e) {
         e = e || window.event;
-        if (e.keyCode == 116) {
+        if (e.keyCode == 116 || e.keyCode == 84) {
           let tools = _.map(larvitar.DEFAULT_TOOLS, "name");
           // remove useless tools for the live example
           tools = _.without(
@@ -188,10 +194,11 @@
             "OrientationMarkers",
             "ScaleOverlay"
           );
+          let increment = e.shiftKey ? -1 : 1;
           tool_counter =
-            tool_counter == tools.length - 1 ? 0 : tool_counter + 1;
+            tool_counter == tools.length - 1 ? 0 : tool_counter + increment;
+          tool_counter = tool_counter < 0 ? 0 : tool_counter;
           let tool = tools[tool_counter];
-          larvitar.larvitar_store.set("leftMouseHandler", tool);
           larvitar.setToolActive(tool);
           $("#active-tool").html("Active Tool: " + tool);
         }

--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -23,10 +23,13 @@
     <div class="row h-100">
       <div id="viewer" class="col-8 h-100" style="background-color: black">
         <p style="position: absolute; color: white">
-          Press "t" to cycle through tools
+          <b>Left Mouse Button:</b> Press "t" to cycle through tools
         </p>
         <p id="active-tool" style="position: absolute; top: 20px; color: white">
           Active Tool: Wwwc
+        </p>
+        <p style="position: absolute; top: 40px; color: white">
+          <b>Right Mouse Button:</b> drag >> Zoom || drag + Ctrl >> Pan
         </p>
       </div>
 
@@ -69,33 +72,49 @@
                 let serie = seriesStack[seriesId];
                 larvitar.renderImage(serie, "viewer");
                 larvitar.addDefaultTools();
-                larvitar.setToolActive("Wwwc");
-                larvitar.addMouseKeyHandlers();
+      
+                let mouseConfig = {
+                  keyboard_shortcuts: {
+                    KEY_A: "Angle",
+                    KEY_L: "Length"
+                  },
+                  mouse_button_right: {
+                    ctrl: "Pan",
+                    default: "Zoom"
+                  },
+                  debug: true
+                };
+      
+                // NOTE: this also activate the tools marked as default for each mouse button
+                larvitar.addMouseKeyHandlers(mouseConfig, ["viewer"]);
               });
             }
-
+      
             let demoFileList = getDemoFileNames();
             _.each(demoFileList, function (demoFile) {
               createFile(demoFile, renderSerie);
             });
-
+      
             let tool_counter = 0;
             document.onkeypress = function (e) {
               e = e || window.event;
-              let tools = _.map(larvitar.DEFAULT_TOOLS, "name");
-              // remove useless tools for the live example
-              tools = _.without(
-                tools,
-                "StackScrollMouseWheel",
-                "TextMarker",
-                "ZoomTouchPinch",
-                "PanMultiTouch",
-                "OrientationMarkers",
-                "ScaleOverlay"
-              );
-              tool_counter = tool_counter == tools.length - 1 ? 0 : tool_counter + 1;
-              let tool = tools[tool_counter];
-              if (e.keyCode == 116) {
+              if (e.keyCode == 116 || e.keyCode == 84) {
+                let tools = _.map(larvitar.DEFAULT_TOOLS, "name");
+                // remove useless tools for the live example
+                tools = _.without(
+                  tools,
+                  "StackScrollMouseWheel",
+                  "TextMarker",
+                  "ZoomTouchPinch",
+                  "PanMultiTouch",
+                  "OrientationMarkers",
+                  "ScaleOverlay"
+                );
+                let increment = e.shiftKey ? -1 : 1;
+                tool_counter =
+                  tool_counter == tools.length - 1 ? 0 : tool_counter + increment;
+                tool_counter = tool_counter < 0 ? 0 : tool_counter;
+                let tool = tools[tool_counter];
                 larvitar.setToolActive(tool);
                 $("#active-tool").html("Active Tool: " + tool);
               }
@@ -106,7 +125,7 @@
       </div>
     </div>
 
-    <script src="../../dist/larvitar.js"></script>
+    <script src="./larvitar.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
     <script
       src="https://code.jquery.com/jquery-3.6.0.slim.min.js"
@@ -132,12 +151,6 @@
       larvitar.initializeImageLoader();
       larvitar.initializeCSTools();
       larvitar.larvitar_store.addViewport("viewer");
-
-      // setInterval(() => {
-      //   console.log(larvitar.larvitar_store);
-      //   console.log(larvitar.larvitar_store.state.viewports.viewer.viewport);
-      // }, 1000);
-      window.larvitar_store = larvitar.larvitar_store;
 
       async function createFile(fileName, cb) {
         let response = await fetch("./demo/" + fileName);

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
           <div class="col-6 text-center">
             <div id="title">
               <p class="lead">Dicom Image Toolkit for CornestoneJS</p>
-              <p class="lead"><i>v0.15.0</i></p>
+              <p class="lead" id="version"><i>v</i></p>
             </div>
           </div>
           <div class="col-3"></div>
@@ -84,5 +84,9 @@
         <div class="col-2"></div>
       </div>
     </div>
+    <script src="examples/larvitar.js"></script>
+    <script>
+      document.getElementById("version").innerHTML += larvitar.VERSION;
+    </script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
           <div class="col-6 text-center">
             <div id="title">
               <p class="lead">Dicom Image Toolkit for CornestoneJS</p>
-              <p class="lead"><i>v0.14.0</i></p>
+              <p class="lead"><i>v0.15.0</i></p>
             </div>
           </div>
           <div class="col-3"></div>

--- a/imaging/image_layers.js
+++ b/imaging/image_layers.js
@@ -7,7 +7,7 @@
 import cornerstone from "cornerstone-core";
 
 // internal libraries
-import { isElement } from "./image_rendering";
+import { isElement } from "./image_utils";
 
 /*
  * This module provides the following functions to be exported:

--- a/imaging/image_rendering.js
+++ b/imaging/image_rendering.js
@@ -458,8 +458,11 @@ export const resetViewports = function (elementIds) {
  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
  * @param {Object} viewportData - The new viewport data
  */
-export const updateViewportData = function (elementId, viewportData) {
-  console.log("updateViewportData");
+export const updateViewportData = function (
+  elementId,
+  viewportData,
+  activeTool
+) {
   let element = isElement(elementId)
     ? elementId
     : document.getElementById(elementId);
@@ -467,8 +470,7 @@ export const updateViewportData = function (elementId, viewportData) {
     console.error("invalid html element: " + elementId);
     return;
   }
-  let activeTool = larvitar_store.get("activeTool");
-  console.log(activeTool);
+  console.log("updateViewportData", activeTool);
   switch (activeTool) {
     case "Wwwc":
     case "WwwcRegion":

--- a/imaging/image_rendering.js
+++ b/imaging/image_rendering.js
@@ -6,13 +6,15 @@
 // external libraries
 import cornerstone from "cornerstone-core";
 import cornerstoneWADOImageLoader from "cornerstone-wado-image-loader";
-import { each, has, throttle } from "lodash";
+import { each, has } from "lodash";
 
 // internal libraries
 import { getFileImageId } from "./loaders/fileLoader";
 import { csToolsCreateStack } from "./tools/tools.main";
+import { toggleMouseToolsListeners } from "./tools/tools.interaction";
 import { larvitar_store } from "./image_store";
 import { applyColorMap } from "./image_colormaps";
+import { isElement } from "./image_utils";
 
 /*
  * This module provides the following functions to be exported:
@@ -29,7 +31,6 @@ import { applyColorMap } from "./image_colormaps";
  * updateViewportData(elementId)
  * toggleMouseHandlers(elementId, disableFlag)
  * storeViewportData(params...)
- * isElement(o)
  * invertImage(elementId)
  * flipImageHorizontal(elementId)
  * flipImageVertical(elementId)
@@ -191,7 +192,8 @@ export const disableViewport = function (elementId) {
     console.error("invalid html element: " + elementId);
     return;
   }
-  toggleMouseHandlers(elementId, true); // flagged true to disable handlers
+  // toggleMouseHandlers(elementId, true); // flagged true to disable handlers
+  toggleMouseToolsListeners(elementId, true);
   cornerstone.disable(element);
 };
 
@@ -344,7 +346,8 @@ export const renderImage = function (seriesStack, elementId, defaultProps) {
   });
 
   csToolsCreateStack(element, series.imageIds, data.imageIndex - 1);
-  toggleMouseHandlers(elementId);
+  // toggleMouseHandlers(elementId);
+  toggleMouseToolsListeners(elementId);
 };
 
 /**
@@ -494,50 +497,50 @@ export const updateViewportData = function (elementId) {
   }
 };
 
-// internal functions for mouse move handlers
-let throttledSave = throttle(function (elementId) {
-  updateViewportData(elementId);
-}, 500);
-function mouseMoveHandler(evt) {
-  throttledSave(evt.srcElement.id);
-}
+// // internal functions for mouse move handlers
+// let throttledSave = throttle(function (elementId) {
+//   updateViewportData(elementId);
+// }, 500);
+// function mouseMoveHandler(evt) {
+//   throttledSave(evt.srcElement.id);
+// }
 
-/**
- * Add event handlers to mouse move
- * @instance
- * @function toggleMouseHandlers
- * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
- * @param {Boolean} disable - If true disable handlers, default is false
- */
-export const toggleMouseHandlers = function (elementId, disable) {
-  let element = isElement(elementId)
-    ? elementId
-    : document.getElementById(elementId);
-  if (!element) {
-    console.error("invalid html element: " + elementId);
-    return;
-  }
+// /**
+//  * Add event handlers to mouse move MOVED to tools.interaction
+//  * @instance
+//  * @function toggleMouseHandlers
+//  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
+//  * @param {Boolean} disable - If true disable handlers, default is false
+//  */
+// export const toggleMouseHandlers = function (elementId, disable) {
+//   let element = isElement(elementId)
+//     ? elementId
+//     : document.getElementById(elementId);
+//   if (!element) {
+//     console.error("invalid html element: " + elementId);
+//     return;
+//   }
 
-  if (disable) {
-    element.removeEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
-    element.removeEventListener(
-      "cornerstonetoolsmousewheel",
-      mouseWheelHandler
-    );
-    return;
-  }
+//   if (disable) {
+//     element.removeEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
+//     element.removeEventListener(
+//       "cornerstonetoolsmousewheel",
+//       mouseWheelHandler
+//     );
+//     return;
+//   }
 
-  element.addEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
+//   element.addEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
 
-  function mouseWheelHandler(evt) {
-    let enabledElement = cornerstone.getEnabledElement(element);
-    let cix =
-      enabledElement.toolStateManager.toolState.stack.data[0]
-        .currentImageIdIndex;
-    larvitar_store.set("sliceId", [evt.target.id, cix + 1]);
-  }
-  element.addEventListener("cornerstonetoolsmousewheel", mouseWheelHandler);
-};
+//   function mouseWheelHandler(evt) {
+//     let enabledElement = cornerstone.getEnabledElement(element);
+//     let cix =
+//       enabledElement.toolStateManager.toolState.stack.data[0]
+//         .currentImageIdIndex;
+//     larvitar_store.set("sliceId", [evt.target.id, cix + 1]);
+//   }
+//   element.addEventListener("cornerstonetoolsmousewheel", mouseWheelHandler);
+// };
 
 /**
  * Store the viewport data into internal storage
@@ -599,23 +602,6 @@ export const storeViewportData = function (
     viewport.voi.windowWidth,
     viewport.voi.windowCenter
   ]);
-};
-
-/**
- * Check if a div tag is a valid DOM HTMLElement
- * @instance
- * @function isElement
- * @param {Object} o - The div tag
- * @return {Boolean} - True if is an element otherwise returns False
- */
-export const isElement = function (o) {
-  return typeof HTMLElement === "object"
-    ? o instanceof HTMLElement //DOM2
-    : o &&
-        typeof o === "object" &&
-        o !== null &&
-        o.nodeType === 1 &&
-        typeof o.nodeName === "string";
 };
 
 /**

--- a/imaging/image_rendering.js
+++ b/imaging/image_rendering.js
@@ -502,51 +502,6 @@ export const updateViewportData = function (
   }
 };
 
-// // internal functions for mouse move handlers
-// let throttledSave = throttle(function (elementId) {
-//   updateViewportData(elementId);
-// }, 500);
-// function mouseMoveHandler(evt) {
-//   throttledSave(evt.srcElement.id);
-// }
-
-// /**
-//  * Add event handlers to mouse move MOVED to tools.interaction
-//  * @instance
-//  * @function toggleMouseHandlers
-//  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
-//  * @param {Boolean} disable - If true disable handlers, default is false
-//  */
-// export const toggleMouseHandlers = function (elementId, disable) {
-//   let element = isElement(elementId)
-//     ? elementId
-//     : document.getElementById(elementId);
-//   if (!element) {
-//     console.error("invalid html element: " + elementId);
-//     return;
-//   }
-
-//   if (disable) {
-//     element.removeEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
-//     element.removeEventListener(
-//       "cornerstonetoolsmousewheel",
-//       mouseWheelHandler
-//     );
-//     return;
-//   }
-
-//   element.addEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
-
-//   function mouseWheelHandler(evt) {
-//     let enabledElement = cornerstone.getEnabledElement(element);
-//     let cix =
-//       enabledElement.toolStateManager.toolState.stack.data[0]
-//         .currentImageIdIndex;
-//     larvitar_store.set("sliceId", [evt.target.id, cix + 1]);
-//   }
-//   element.addEventListener("cornerstonetoolsmousewheel", mouseWheelHandler);
-// };
-
 /**
  * Store the viewport data into internal storage
  * @instance

--- a/imaging/image_rendering.js
+++ b/imaging/image_rendering.js
@@ -470,7 +470,6 @@ export const updateViewportData = function (
     console.error("invalid html element: " + elementId);
     return;
   }
-  console.log("updateViewportData", activeTool);
   switch (activeTool) {
     case "Wwwc":
     case "WwwcRegion":

--- a/imaging/image_rendering.js
+++ b/imaging/image_rendering.js
@@ -456,8 +456,10 @@ export const resetViewports = function (elementIds) {
  * @instance
  * @function updateViewportData
  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
+ * @param {Object} viewportData - The new viewport data
  */
-export const updateViewportData = function (elementId) {
+export const updateViewportData = function (elementId, viewportData) {
+  console.log("updateViewportData");
   let element = isElement(elementId)
     ? elementId
     : document.getElementById(elementId);
@@ -465,32 +467,33 @@ export const updateViewportData = function (elementId) {
     console.error("invalid html element: " + elementId);
     return;
   }
-  let viewport = cornerstone.getViewport(element);
-  let activeTool = larvitar_store.get("leftMouseHandler");
+  let activeTool = larvitar_store.get("activeTool");
+  console.log(activeTool);
   switch (activeTool) {
     case "Wwwc":
+    case "WwwcRegion":
       // sync viewports if needed
       let elements = cornerstone.getEnabledElements();
       each(elements, function (el) {
         larvitar_store.set("contrast", [
           el.element.id,
-          viewport.voi.windowWidth,
-          viewport.voi.windowCenter
+          viewportData.voi.windowWidth,
+          viewportData.voi.windowCenter
         ]);
       });
       break;
     case "Pan":
       larvitar_store.set("translation", [
         elementId,
-        viewport.translation.x,
-        viewport.translation.y
+        viewportData.translation.x,
+        viewportData.translation.y
       ]);
       break;
     case "Zoom":
-      larvitar_store.set("scale", [elementId, viewport.scale]);
+      larvitar_store.set("scale", [elementId, viewportData.scale]);
       break;
     case "Rotate":
-      larvitar_store.set("rotation", [elementId, viewport.rotation]);
+      larvitar_store.set("rotation", [elementId, viewportData.rotation]);
       break;
     default:
       break;

--- a/imaging/image_store.js
+++ b/imaging/image_store.js
@@ -68,7 +68,8 @@ class Larvitar_Store {
     this.state = {
       manager: null,
       series: {}, // seriesUID: {imageIds:[], progress:value}
-      activeTool: "Wwwc",
+      leftActiveTool: "Wwwc",
+      rightActiveTool: "Zoom",
       colormapId: "gray",
       viewports: {},
       errorLog: null,

--- a/imaging/image_store.js
+++ b/imaging/image_store.js
@@ -68,8 +68,7 @@ class Larvitar_Store {
     this.state = {
       manager: null,
       series: {}, // seriesUID: {imageIds:[], progress:value}
-      leftMouseHandler: "Wwwc",
-      rightMouseHandler: "Wwwc",
+      activeTool: "Wwwc",
       colormapId: "gray",
       viewports: {},
       errorLog: null,

--- a/imaging/image_tools.js
+++ b/imaging/image_tools.js
@@ -17,7 +17,7 @@ import { DiameterTool } from "./tools/diameterTool";
 import { getImageIdFromSlice } from "./loaders/nrrdLoader";
 import { getSeriesDataFromLarvitarManager } from "./loaders/commonLoader";
 import { parseContours } from "./image_contours";
-import { isElement } from "./image_rendering";
+import { isElement } from "./image_utils";
 
 /*
  * This module provides the following functions to be exported:

--- a/imaging/image_utils.js
+++ b/imaging/image_utils.js
@@ -49,6 +49,7 @@ const resliceTable = {
  * getReslicedPixeldata(imageId, originalData, reslicedData)
  * getDistanceBetweenSlices(seriesData, sliceIndex1, sliceIndex2)
  * parseTag(dataSet, propertyName, element)
+ * isElement(o)
  */
 
 /**
@@ -1488,4 +1489,21 @@ const TYPES_TO_TYPEDARRAY = {
 
   float: Float32Array,
   double: Float64Array
+};
+
+/**
+ * Check if a div tag is a valid DOM HTMLElement
+ * @instance
+ * @function isElement
+ * @param {Object} o - The div tag
+ * @return {Boolean} - True if is an element otherwise returns False
+ */
+export const isElement = function (o) {
+  return typeof HTMLElement === "object"
+    ? o instanceof HTMLElement //DOM2
+    : o &&
+        typeof o === "object" &&
+        o !== null &&
+        o.nodeType === 1 &&
+        typeof o.nodeName === "string";
 };

--- a/imaging/tools/tools.interaction.js
+++ b/imaging/tools/tools.interaction.js
@@ -33,6 +33,8 @@ export function addMouseKeyHandlers(config, viewports) {
       : [];
 
     if (codes.includes(evt.keyCode) && evt.altKey) {
+      evt.preventDefault(); // avoid browser menu selections
+
       let key = Object.keys(config.keyboard_shortcuts)
         .filter(key => keyCodes[key] == evt.keyCode)
         .pop();

--- a/imaging/tools/tools.interaction.js
+++ b/imaging/tools/tools.interaction.js
@@ -7,6 +7,8 @@ import { updateViewportData } from "../image_rendering";
 import { throttle } from "lodash";
 import * as keyCodes from "keycode-js";
 
+import cornerstone from "cornerstone-core";
+
 /**
  * TOOLS INTERACTIONS TODOS:
  * - enable touch controls
@@ -135,36 +137,30 @@ export const toggleMouseToolsListeners = function (elementId, disable) {
     return;
   }
 
-  // mouse move handler
-  let throttledSave = throttle(function (evt) {
+  // mouse move handler (throttled)
+  let mouseMoveHandler = throttle(function (evt) {
     console.log(evt);
     let activeTool =
       evt.detail.buttons == 1
         ? larvitar_store.get("leftActiveTool")
         : larvitar_store.get("rightActiveTool");
     updateViewportData(evt.srcElement.id, evt.detail.viewport, activeTool);
-  }, 2000);
-  // function mouseMoveHandler(evt) {
-  //   throttledSave(evt);
-  // }
+  }, 500);
+
   // mouse wheel handler
   function mouseWheelHandler(evt) {
-    let enabledElement = cornerstone.getEnabledElement(element);
-    let cix =
-      enabledElement.toolStateManager.toolState.stack.data[0]
-        .currentImageIdIndex;
-    larvitar_store.set("sliceId", [evt.target.id, cix + 1]);
+    larvitar_store.set("sliceId", [evt.target.id, evt.detail.newImageIdIndex]);
   }
 
   if (disable) {
     element.removeEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
     element.removeEventListener(
-      "cornerstonetoolsmousewheel",
+      "cornerstonetoolsstackscroll",
       mouseWheelHandler
     );
     return;
   }
 
-  element.addEventListener("cornerstonetoolsmousedrag", throttledSave);
-  element.addEventListener("cornerstonetoolsmousewheel", mouseWheelHandler);
+  element.addEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
+  element.addEventListener("cornerstonetoolsstackscroll", mouseWheelHandler);
 };

--- a/imaging/tools/tools.interaction.js
+++ b/imaging/tools/tools.interaction.js
@@ -143,10 +143,10 @@ export const toggleMouseToolsListeners = function (elementId, disable) {
         ? larvitar_store.get("leftActiveTool")
         : larvitar_store.get("rightActiveTool");
     updateViewportData(evt.srcElement.id, evt.detail.viewport, activeTool);
-  }, 500);
-  function mouseMoveHandler(evt) {
-    throttledSave(evt);
-  }
+  }, 2000);
+  // function mouseMoveHandler(evt) {
+  //   throttledSave(evt);
+  // }
   // mouse wheel handler
   function mouseWheelHandler(evt) {
     let enabledElement = cornerstone.getEnabledElement(element);
@@ -165,6 +165,6 @@ export const toggleMouseToolsListeners = function (elementId, disable) {
     return;
   }
 
-  element.addEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
+  element.addEventListener("cornerstonetoolsmousedrag", throttledSave);
   element.addEventListener("cornerstonetoolsmousewheel", mouseWheelHandler);
 };

--- a/imaging/tools/tools.interaction.js
+++ b/imaging/tools/tools.interaction.js
@@ -2,7 +2,9 @@ import { DEFAULT_MOUSE_KEYS } from "./tools.default";
 import { setToolActive } from "./tools.main";
 import { isElement } from "../image_utils";
 import { larvitar_store } from "../image_store";
+import { updateViewportData } from "../image_rendering";
 
+import { throttle } from "lodash";
 import * as keyCodes from "keycode-js";
 
 /**
@@ -41,7 +43,6 @@ export function addMouseKeyHandlers(config, viewports) {
         .pop();
       if (config.debug) console.log("active", config.keyboard_shortcuts[key]);
       setToolActive(config.keyboard_shortcuts[key], {}, viewports);
-      larvitar_store.set("leftMouseHandler", config.keyboard_shortcuts[key]);
       document.addEventListener("keydown", onKeyDown, { once: true });
     }
     // right drag + shift
@@ -56,7 +57,6 @@ export function addMouseKeyHandlers(config, viewports) {
         { mouseButtonMask: 2 },
         viewports
       );
-      larvitar_store.set("rightMouseHandler", config.mouse_button_right.shift);
       document.addEventListener("keyup", onKeyUp, { once: true });
     }
     // right drag + ctrl
@@ -71,7 +71,6 @@ export function addMouseKeyHandlers(config, viewports) {
         { mouseButtonMask: 2 },
         viewports
       );
-      larvitar_store.set("rightMouseHandler", config.mouse_button_right.ctrl);
       document.addEventListener("keyup", onKeyUp, { once: true });
     }
     // leave default
@@ -89,7 +88,6 @@ export function addMouseKeyHandlers(config, viewports) {
       { mouseButtonMask: 2 },
       viewports
     );
-    larvitar_store.set("rightMouseHandler", config.mouse_button_right.default);
     document.addEventListener("keydown", onKeyDown, { once: true });
   }
 
@@ -101,7 +99,6 @@ export function addMouseKeyHandlers(config, viewports) {
       { mouseButtonMask: 2 },
       viewports
     );
-    larvitar_store.set("rightMouseHandler", config.mouse_button_right.default);
   }
 
   if (config.mouse_button_left && config.mouse_button_left.default) {
@@ -110,7 +107,6 @@ export function addMouseKeyHandlers(config, viewports) {
       { mouseButtonMask: 1 },
       viewports
     );
-    larvitar_store.set("leftMouseHandler", config.mouse_button_left.default);
   }
 
   document.addEventListener("keydown", onKeyDown, { once: true });
@@ -133,11 +129,11 @@ export const toggleMouseToolsListeners = function (elementId, disable) {
   }
 
   // mouse move handler
-  let throttledSave = throttle(function (elementId) {
-    updateViewportData(elementId);
+  let throttledSave = throttle(function (elementId, data) {
+    updateViewportData(elementId, data);
   }, 500);
   function mouseMoveHandler(evt) {
-    throttledSave(evt.srcElement.id);
+    throttledSave(evt.srcElement.id, evt.detail.viewport);
   }
   // mouse wheel handler
   function mouseWheelHandler(evt) {

--- a/imaging/tools/tools.interaction.js
+++ b/imaging/tools/tools.interaction.js
@@ -8,6 +8,13 @@ import { throttle } from "lodash";
 import * as keyCodes from "keycode-js";
 
 /**
+ * TOOLS INTERACTIONS TODOS:
+ * - enable touch controls
+ * - rework active tools / ui labels sync (we can get all active tools from cornerstoneTools state, then check the button / input method to update the correct label, or update all props scale, translation and voi)
+ * - use config to setup all interactions (mouse left/right, keyboard shortcuts, touch inputs)
+ */
+
+/**
  * Setup mouse handler modifiers and keyboard shortcuts
  * NOTE: at the moment only mouse right button is affected
  * Improvements could be:
@@ -129,11 +136,16 @@ export const toggleMouseToolsListeners = function (elementId, disable) {
   }
 
   // mouse move handler
-  let throttledSave = throttle(function (elementId, data) {
-    updateViewportData(elementId, data);
+  let throttledSave = throttle(function (evt) {
+    console.log(evt);
+    let activeTool =
+      evt.detail.buttons == 1
+        ? larvitar_store.get("leftActiveTool")
+        : larvitar_store.get("rightActiveTool");
+    updateViewportData(evt.srcElement.id, evt.detail.viewport, activeTool);
   }, 500);
   function mouseMoveHandler(evt) {
-    throttledSave(evt.srcElement.id, evt.detail.viewport);
+    throttledSave(evt);
   }
   // mouse wheel handler
   function mouseWheelHandler(evt) {

--- a/imaging/tools/tools.interaction.js
+++ b/imaging/tools/tools.interaction.js
@@ -7,8 +7,6 @@ import { updateViewportData } from "../image_rendering";
 import { throttle } from "lodash";
 import * as keyCodes from "keycode-js";
 
-import cornerstone from "cornerstone-core";
-
 /**
  * TOOLS INTERACTIONS TODOS:
  * - enable touch controls
@@ -139,7 +137,6 @@ export const toggleMouseToolsListeners = function (elementId, disable) {
 
   // mouse move handler (throttled)
   let mouseMoveHandler = throttle(function (evt) {
-    console.log(evt);
     let activeTool =
       evt.detail.buttons == 1
         ? larvitar_store.get("leftActiveTool")

--- a/imaging/tools/tools.main.js
+++ b/imaging/tools/tools.main.js
@@ -16,6 +16,7 @@ import {
   DEFAULT_SETTINGS,
   dvTools
 } from "./tools.default";
+import { larvitar_store } from "../image_store";
 
 /**
  * Initialize cornerstone tools with default configuration (extended with custom configuration)
@@ -200,6 +201,9 @@ const setToolActive = function (toolName, options, viewports) {
       tryUpdateImage(enel.element);
     });
   }
+
+  // set active tool in larvitar store
+  larvitar_store.set("activeTool", toolName);
 };
 
 /**

--- a/imaging/tools/tools.main.js
+++ b/imaging/tools/tools.main.js
@@ -158,7 +158,7 @@ export const addDefaultTools = function (elementId) {
     }
 
     if (tool.defaultActive) {
-      setToolActive(tool.name, tool.options);
+      setToolActive(tool.name, tool.options, [], true);
     }
   });
 };
@@ -181,8 +181,9 @@ function tryUpdateImage(element) {
  * @param {String} toolName - The tool name.
  * @param {Object} options - The custom options. @default from tools.default.js
  * @param {Array} viewports - The hmtl element id to be used for tool initialization.
+ * @param {Boolean} doNotSetInStore - Flag to avoid setting in store (useful on tools initialization eg in addDefaultTools). NOTE: This is just a hack, we must rework tools/ui sync.
  */
-const setToolActive = function (toolName, options, viewports) {
+const setToolActive = function (toolName, options, viewports, doNotSetInStore) {
   let defaultOpt = DEFAULT_TOOLS[toolName].options;
   extend(defaultOpt, options);
 
@@ -203,7 +204,11 @@ const setToolActive = function (toolName, options, viewports) {
   }
 
   // set active tool in larvitar store
-  larvitar_store.set("activeTool", toolName);
+  if (!doNotSetInStore) {
+    defaultOpt.mouseButtonMask && defaultOpt.mouseButtonMask == 1
+      ? larvitar_store.set("leftActiveTool", toolName)
+      : larvitar_store.set("rightActiveTool", toolName);
+  }
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+import pkg from "./package.json";
+const VERSION = pkg.version;
+console.log(`LARVITAR v${VERSION}`);
+
 import cornerstone from "cornerstone-core";
 import cornerstoneTools from "cornerstone-tools";
 import cornerstoneWADOImageLoader from "cornerstone-wado-image-loader";
@@ -179,6 +183,7 @@ import {
 } from "./imaging/tools/tools.interaction";
 
 export {
+  VERSION,
   // global cornerstone variables
   cornerstone,
   cornerstoneTools,

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ import {
   updateImage,
   resetViewports,
   updateViewportData,
-  toggleMouseHandlers,
+  // toggleMouseHandlers,
   storeViewportData,
   invertImage,
   flipImageHorizontal,
@@ -173,7 +173,10 @@ import {
 
 import { saveAnnotations, loadAnnotations } from "./imaging/tools/tools.io";
 
-import { addMouseKeyHandlers } from "./imaging/tools/tools.interaction";
+import {
+  addMouseKeyHandlers,
+  toggleMouseToolsListeners
+} from "./imaging/tools/tools.interaction";
 
 export {
   // global cornerstone variables
@@ -239,7 +242,8 @@ export {
   updateImage,
   resetViewports,
   updateViewportData,
-  toggleMouseHandlers,
+  // toggleMouseHandlers,
+  toggleMouseToolsListeners,
   storeViewportData,
   invertImage,
   flipImageHorizontal,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dicom",
     "imaging"
   ],
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "javascript library for loading, rendering and interact with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ BREAKING CHANGE : **setToolActive** has a new signature: setToolActive(toolName, options, viewports, doNotSetInStore). The latter param is optional. 

**Note:** IMHO I think we should update all 3 params (scale, translation, voi) at each mouse interaction. This would mean delete all the get / set listeners for handles each time a new tool is activated (press left / right button and shift / ctrl keys). A lot less code, since we would not need to know which tool is active. Moreover, it will fit also the "touch" interactions, otherwise we will have to set another "touchActiveTool". 