### PR TITLE
fix: fixed nrrd rendering, wrong row/col index

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Dicom Image Toolkit for CornestoneJS
 
-### Current version: 0.17.0
+### Current version: 0.17.1
 
 ### Latest Stable version: 0.16.2
 

--- a/imaging/loaders/nrrdLoader.js
+++ b/imaging/loaders/nrrdLoader.js
@@ -86,8 +86,8 @@ export const buildNrrdImage = function (volume, seriesId, custom_header) {
       volume.header["space directions"][2][2] *
         volume.header["space directions"][2][2]
   );
-  header.volume.rows = volume.header.sizes[0];
-  header.volume.cols = volume.header.sizes[1];
+  header.volume.rows = volume.header.sizes[1];
+  header.volume.cols = volume.header.sizes[0];
   header.volume.numberOfSlices = volume.header.sizes[2];
   header.volume.imagePosition = volume.header["space origin"];
   header.volume.pixelSpacing = [spacing_x, spacing_y];
@@ -107,8 +107,8 @@ export const buildNrrdImage = function (volume, seriesId, custom_header) {
     ? custom_header.acquisition_date
     : "";
 
-  let rows = volume.header.sizes[0];
-  let cols = volume.header.sizes[1];
+  let rows = volume.header.sizes[1];
+  let cols = volume.header.sizes[0];
   let frames = volume.header.sizes[2];
   let iop = volume.header["space directions"][0].concat(
     volume.header["space directions"][1]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dicom",
     "imaging"
   ],
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "javascript library for loading, rendering and interact with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
My guess was right, it was a problem of the nrrd loader.
Since we always tested nrrd images with same number of rows & columns, this bug was never highlighted.
The problem was simple, rows index and columns index were inverted.

It's fixed in v0.17.1 which is not yet on npm.

fix #156 

![Screenshot 2021-07-15 095406](https://user-images.githubusercontent.com/572819/125750863-ac7bbf73-80c6-4bcf-9b5a-ea39b0562ae9.png)
