### PR TITLE
feat: utils brush api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Dicom Image Toolkit for CornerstoneJS
 
-### Current version: 1.3.3
+### Current version: 1.3.4
 
-### Latest Stable version: 1.3.3
+### Latest Stable version: 1.3.4
 
-### Latest Published Release: 1.3.3
+### Latest Published Release: 1.3.4
 
 This library provides common DICOM functionalities to be used in web-applications: it's wrapper that simplifies the use of cornerstone-js environment.
 Orthogonal multiplanar reformat is included as well as custom loader/exporter for nrrd files and [Vuex](https://vuex.vuejs.org/) custom integration.

--- a/imaging/tools/segmentation.js
+++ b/imaging/tools/segmentation.js
@@ -18,6 +18,7 @@ import { updateStackToolState } from "../imageTools";
 
 // custom code
 import { setLabelmap3DForElement } from "./setLabelMap3D";
+import { each } from "hammerjs";
 // override function
 setters.labelmap3DForElement = setLabelmap3DForElement;
 
@@ -419,22 +420,37 @@ export function clearSegmentationState() {
 
 /**
  * Enable brushing
- * @param {Number} dimension - The initial brush radius
- * @param {Array} thresholds - The threshold values (min and max)
+ * NOTE: if options contains `thresholds`, ThresholdsBrush is activated, otherwise BrushTool is activated.
+ * Anyway, the activated tool name is returned
+ * @param {Object} options - An object containing configuration values (eg radius, thresholds, etc...)
  */
-export function enableBrushTool(dimension, thresholds) {
-  segModule.configuration.radius = dimension;
-  segModule.configuration.thresholds = thresholds;
-  setToolActive("ThresholdsBrush");
+export function enableBrushTool(viewports, options) {
+  console.log("enable", options);
+  setBrushProps(options);
+  const brushType = "thresholds" in options ? "ThresholdsBrush" : "Brush";
+  setToolActive(brushType, viewports);
+  return brushType;
 }
 
 /**
  * Disable brushing
- * @param {String} toolToActivate - The name of the tool to activate after removing the brush
+ * This function disables both brush tools, if found active on `viewports`
+ * @param {String} toolToActivate - The name of the tool to activate after removing the brush @optional
  */
-export function disableBrushTool(toolToActivate) {
-  setToolDisabled("Brush");
-  setToolActive(toolToActivate);
+export function disableBrushTool(viewports, toolToActivate) {
+  each(viewports, viewport => {
+    const el = document.getElementById(viewport);
+    if (cornerstoneTools.isToolActiveForElement(el, "ThresholdsBrush")) {
+      setToolDisabled("ThresholdsBrush", [viewport]);
+    }
+    if (cornerstoneTools.isToolActiveForElement(el, "Brush")) {
+      setToolDisabled("Brush", [viewport]);
+    }
+  });
+
+  if (toolToActivate) {
+    setToolActive(toolToActivate);
+  }
 }
 
 /**

--- a/imaging/tools/segmentations.md
+++ b/imaging/tools/segmentations.md
@@ -29,7 +29,7 @@ TODO
 
 # Larvitar segmentation API
 
-TODO
+To enable brush tools, user can call directly the `setToolActive` / `setToolDisabled` api, in this case he has to handle brush type (thresholds or not), props (radius etc) and tool switching. Otherwise, Larvitar implements the utility functions `enableBrushTool` and `disableBrushTool` that internally handle brush type and props with a single call.
 
 # Customization
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "javascript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
User has now two ways to enable brush tools: 
- directly the `setToolActive` / `setToolDisabled` api, in this case he has to handle brush type (thresholds or not), props (radius etc) and tool switching
- Otherwise, Larvitar implements the utility functions `enableBrushTool` and `disableBrushTool` that internally handle brush type and props with a single call.