### PR TITLE
fix: Vue dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Dicom Image Toolkit for CornerstoneJS
 
-### Current version: 1.5.7
+### Current version: 1.5.8
 
-### Latest Published Release: 1.5.7
+### Latest Published Release: 1.5.8
 
 This library provides common DICOM functionalities to be used in web-applications: it's wrapper that simplifies the use of cornerstone-js environment.
 Orthogonal multiplanar reformat is included as well as custom loader/exporter for nrrd files and [Vuex](https://vuex.vuejs.org/) custom integration.

--- a/docs/documentation/imageStore.js.html
+++ b/docs/documentation/imageStore.js.html
@@ -360,12 +360,14 @@ class Larvitar_Store {
  * @param {Object} vuexStore - The app vuex store [optional]
  * @param {String} vuexModule - The name of the vuex store module, can be null
  * @param {Boolean} registerModule - If true, the module is registered under Vuex global store
+ * @param {Object} _Vue - The Vue instance
  */
 
-export function initLarvitarStore(vuexStore, vuexModule, registerModule) {
+export function initLarvitarStore(vuexStore, vuexModule, registerModule, _Vue) {
   if (vuexStore) {
     larvitar_store = new Larvitar_Store(vuexStore, vuexModule);
     if (registerModule) {
+      larvitar.defineVue(_Vue);
       vuexStore.registerModule(vuexModule, larvitar);
     }
   } else {

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -73,8 +73,8 @@
 </p>
 <h1 id="larvitar">Larvitar</h1>
 <h2 id="dicom-image-toolkit-for-cornerstonejs">Dicom Image Toolkit for CornerstoneJS</h2>
-<h3 id="current-version%3A-1.5.7">Current version: 1.5.7</h3>
-<h3 id="latest-published-release%3A-1.5.7">Latest Published Release: 1.5.7</h3>
+<h3 id="current-version%3A-1.5.8">Current version: 1.5.8</h3>
+<h3 id="latest-published-release%3A-1.5.8">Latest Published Release: 1.5.8</h3>
 <p>This library provides common DICOM functionalities to be used in web-applications: it's wrapper that simplifies the use of cornerstone-js environment.<br>
 Orthogonal multiplanar reformat is included as well as custom loader/exporter for nrrd files and <a href="https://vuex.vuejs.org/">Vuex</a> custom integration.</p>
 <ul>

--- a/docs/documentation/module-imaging_imageStore.html
+++ b/docs/documentation/module-imaging_imageStore.html
@@ -255,7 +255,7 @@ for data config store.</p></li></ul></dd>
 
     
 
-    <h4 class="name" id=".initLarvitarStore"><span class="type-signature type-signature-static">(static) </span>initLarvitarStore<span class="signature">(vuexStore, vuexModule, registerModule)</span><span class="type-signature"></span></h4>
+    <h4 class="name" id=".initLarvitarStore"><span class="type-signature type-signature-static">(static) </span>initLarvitarStore<span class="signature">(vuexStore, vuexModule, registerModule, _Vue)</span><span class="type-signature"></span></h4>
 
     
 
@@ -271,7 +271,7 @@ for data config store.</p></li></ul></dd>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="imageStore.js.html">imageStore.js</a>, <a href="imageStore.js.html#line310">line 310</a>
+        <a href="imageStore.js.html">imageStore.js</a>, <a href="imageStore.js.html#line311">line 311</a>
     </li></ul></dd>
     
 
@@ -409,6 +409,30 @@ for data config store.</p></li></ul></dd>
             
 
             <td class="description last"><p>If true, the module is registered under Vuex global store</p></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>_Vue</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">Object</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"><p>The Vue instance</p></td>
         </tr>
 
     

--- a/imaging/imageStore.js
+++ b/imaging/imageStore.js
@@ -305,12 +305,14 @@ class Larvitar_Store {
  * @param {Object} vuexStore - The app vuex store [optional]
  * @param {String} vuexModule - The name of the vuex store module, can be null
  * @param {Boolean} registerModule - If true, the module is registered under Vuex global store
+ * @param {Object} _Vue - The Vue instance
  */
 
-export function initLarvitarStore(vuexStore, vuexModule, registerModule) {
+export function initLarvitarStore(vuexStore, vuexModule, registerModule, _Vue) {
   if (vuexStore) {
     larvitar_store = new Larvitar_Store(vuexStore, vuexModule);
     if (registerModule) {
+      larvitar.defineVue(_Vue);
       vuexStore.registerModule(vuexModule, larvitar);
     }
   } else {

--- a/modules/vuex/larvitar.js
+++ b/modules/vuex/larvitar.js
@@ -1,6 +1,5 @@
-// Larvitar Vuex storage
-
-import Vue from "vue";
+// Larvitar Vuex instance
+var Vue = null;
 
 // default viewport store object
 const DEFAULT_VIEWPORT = {
@@ -180,4 +179,9 @@ export default {
     setContrast: ({ commit }, [id, windowWidth, windowCenter]) =>
       commit("canvas", { id, d: { voi: { windowWidth, windowCenter } } })
   }
+};
+
+// define Vue instance from outside dependency
+export const defineVue = _Vue => {
+  Vue = _Vue;
 };


### PR DESCRIPTION
removed the Vue dependency.
In order to use the larvitar store from a Vue.js application user needs to call larvitar store passing also Vue instance as additional parameter

`initLarvitarStore(store, "larvitar", true, Vue);`
where store is the Vuex Store and Vue is the Vue instance (`import Vue from "vue";`)