### PR TITLE
feat: updateImage deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+
+## [3.2.0] - 2025-03-17
+
+🚀 Key Changes:
+- `updateImage` is now deprecated:
+  - The method `updateImage` should no longer be used and will be removed in future versions.
+
+- `renderImage` is now the single rendering method:
+  - All functionalities previously handled by `updateImage` are now integrated into `renderImage`, which becomes the standard method for image rendering.
+
+**Deprecated Aliases for Backward Compatibility**:
+  - `updateImage → renderImage`
+
+
 ## [3.1.0] - 2025-03-03
 
 🚀 Features Added:

--- a/docs/api/rendering.md
+++ b/docs/api/rendering.md
@@ -99,18 +99,27 @@ export const renderImage = function (
 3. **Prepare Image Data**
    - Extracts series metadata and retrieves the appropriate image ID.
    - If the image ID is missing, it logs a warning and rejects the promise.
+   - If `defaultProps` is provided, it applies viewport settings.
 
-4. **Load and Render the Image**
+4. **Check for Series Change**
+   - Determines whether the current series differs from the previously loaded one.
+
+5. **Handle DSA (Digital Subtraction Angiography)**
+   - If the series is DSA, sets the pixel shift using `setPixelShift` to ensure proper rendering.
+   - If the series is DSA extract the imageId from the dsa series stack.
+
+6. **Load and Render the Image**
    - Loads the image using `cornerstone.loadImage` or `cornerstone.loadAndCacheImage`.
+   - If `cached` is true, the image is cached for future use.
    - Displays the image in the specified viewport.
    - Applies default viewport settings, including window width/center.
    - Fits the image to the window and applies transformations (scale, translation, colormap) if specified in `options.defaultProps`.
 
-5. **Store Viewport Data**
+7. **Store Viewport Data**
    - Saves viewport settings to ensure consistency across different renderings.
    - Sets `ready` status in the store to `true`.
 
-6. **Performance Logging and Cleanup**
+8. **Performance Logging and Cleanup**
    - Logs the time taken for rendering.
    - Clears memory references to avoid memory leaks.
 

--- a/docs/api/rendering.md
+++ b/docs/api/rendering.md
@@ -32,8 +32,7 @@ These functions enable rendering of images from various sources and formats.
   - **PNG & JPEG:** Directly displayed as standard 2D images.
   - **PDF:** Requires conversion to an image format before rendering.
 - `renderWebImage(url, elementId)`: Loads and renders an image from a URL (PNG, JPEG, or other supported formats) into the designated viewport.
-- `renderImage(series, elementId, options)`: Displays an image series in the viewport while applying default rendering properties such as contrast, brightness, and annotations or caching settings.
-- `updateImage(series, elementId, imageIndex)`: Updates the displayed image in a given series, ensuring smooth navigation between slices or frames.
+- `renderImage(series, elementId, options)`: Displays an image series in the viewport while applying default rendering properties such as contrast, brightness, and annotations or caching settings. It also updates the displayed image in a given series, ensuring smooth navigation between slices or frames
 
 ### Viewport Management
 
@@ -59,7 +58,7 @@ Image transformation functions allow real-time modifications to improve visualiz
 
 ## Rendering API `renderImage`
 
-The `renderImage` function is responsible for rendering a DICOM image onto a specified HTML element using the cornerstone.js library. It initializes the rendering environment, loads the image, and applies optional transformations.
+The `renderImage` function is responsible for rendering a DICOM image onto a specified HTML element using the cornerstone.js library. It initializes the rendering environment, loads the image, and applies optional transformations. It supports caching for improved performance.
 
 ### Function Signature
 
@@ -138,75 +137,16 @@ larvitar.renderImage(seriesStack, "viewer", {
 - If the specified HTML element is invalid, the function rejects the promise with an error message.
 - If no image ID is found, the function logs a warning and rejects the promise.
 - If the viewport settings cannot be retrieved, the function logs an error and rejects the promise.
+  
+### Limitations
+- Requires the series to have valid image IDs and metadata.
+- If using DSA, ensures `setPixelShift` is called appropriately.
 
 ### Notes
 
 - This function is optimized to work with both single-frame and multi-frame DICOM images.
 - Uses `cornerstoneDICOMImageLoader` for fetching and handling image data.
 - Implements caching and efficient rendering techniques to improve performance.
-
-## Rendering API `updateImage`
-
-The `updateImage` function updates the cornerstone image within a viewport by rendering a new image at the specified `imageIndex`. It supports caching for improved performance and can handle 4D series updates.
-
-### Function Signature
-
-```typescript
-export const updateImage = function(
-  series: Series,
-  elementId: string | HTMLElement,
-  imageIndex: number,
-  cacheImage: boolean
-): Promise<void>
-```
-
-### Parameters
-| Parameter   | Type                     | Description |
-|------------|--------------------------|-------------|
-| `series`   | `Series`                 | The original series data object. |
-| `elementId` | `string \| HTMLElement` | The HTML element ID or DOM element used for rendering. |
-| `imageIndex` | `number`                 | The index of the image to be rendered. |
-| `cacheImage` | `boolean`                 | A flag to determine if the image should be cached. |
-
-### Returns
-Returns a `Promise<void>` that resolves when the image update completes.
-
-### How It Works
-1. **Retrieves the Element:**
-   - Identifies the target HTML element.
-   - Throws an error if the element is not found.
-
-2. **Determines Image ID:**
-   - If Digital Subtraction Angiography (DSA) is enabled, it selects the appropriate image ID.
-   - Handles metadata-only objects and ensures pixel data is available before updating.
-
-3. **Handles 4D Series Updates:**
-   - Updates `timestamp` and `timeId` if the series is 4D.
-
-4. **Loads and Displays the Image:**
-   - Uses `cornerstone.loadAndCacheImage` if caching is enabled.
-   - Otherwise, directly calls `cornerstone.loadImage`.
-   - Updates viewport state and logs performance timing.
-
-### Example Usage
-```typescript
-updateImage(seriesData, "viewer", 5, true)
-  .then(() => console.log("Image updated successfully."))
-  .catch((error) => console.error("Error updating image:", error));
-```
-
-### Error Handling
-- Throws an error if the target HTML element is not found.
-- Rejects if an invalid `imageIndex` is provided.
-- Logs performance timing when enabled.
-- 
-### Performance Considerations
-- Uses caching when `cacheImage` is set to `true` for better performance.
-- Measures execution time if performance monitoring is enabled.
-
-### Limitations
-- Requires the series to have valid image IDs and metadata.
-- If using DSA, ensures `setPixelShift` is called appropriately.
 
 ## Rendering API `renderDICOMPDF`
 

--- a/docs/examples/4d.html
+++ b/docs/examples/4d.html
@@ -300,7 +300,9 @@ larvitar
                           ? sliceId - (frames_number - 1)
                           : sliceId + 1;
 
-                      larvitar.updateImage(serie, "viewer", sliceId, false);
+                      larvitar.renderImage(serie, "viewer", {
+                        defaultProps: { sliceNumber: sliceId }
+                      });
                       changeStamps();
                     }, 100);
                   } else {

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -374,7 +374,7 @@ larvitar
       }
 
       // Function to handle the full list once it's ready
-      function processFileList(demoFiles) {
+      function processFileList() {
         renderSerie();
       }
 
@@ -492,7 +492,6 @@ larvitar
       larvitar.registerMultiFrameImageLoader();
       larvitar.initializeCSTools();
       larvitar.store.initialize();
-      larvitar.store.addViewport("viewer");
 
       // set log level to debug
       larvitar.setLogLevel("debug");
@@ -532,35 +531,24 @@ larvitar
 
       function renderSerie() {
         larvitar.resetImageManager();
+        larvitar.disableViewport("viewer");
+        larvitar.store.addViewport("viewer");
         larvitar
           .readFiles(demoFiles)
           .then(seriesStack => {
+            //populate the image manager with the series
+            for (const [uniqueId, data] of Object.entries(seriesStack)) {
+              larvitar.populateImageManager(uniqueId, data);
+            }
             // render the first series of the study
             let seriesId = Object.keys(seriesStack)[0];
-            larvitar.populateImageManager(seriesId, seriesStack[seriesId]);
             let manager = larvitar.getImageManager();
             let serie = manager[seriesId];
             larvitar.renderImage(serie, "viewer").then(() => {
               larvitar.logger.debug("Image has been rendered");
               hideSpinner(); // Hide the spinner when all files are processed
-              larvitar.resetViewports(["viewer"]);
               larvitar.addDefaultTools();
               larvitar.setToolActive("Wwwc");
-            });
-            // optionally cache the series
-
-            Object.keys(seriesStack).forEach(seriesId => {
-              larvitar.populateImageManager(seriesId, seriesStack[seriesId]);
-              larvitar.cacheImages(seriesStack[seriesId], function (resp) {
-                if (resp.loading == 100) {
-                  let cache = larvitar.cornerstone.imageCache;
-                  larvitar.logger.debug(
-                    "Cache size: ",
-                    cache.getCacheInfo().cacheSizeInBytes / 1e6,
-                    "Mb"
-                  );
-                }
-              });
             });
 
             series = serie;
@@ -609,7 +597,6 @@ larvitar
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
             hideSpinner(); // Hide the spinner when all files are processed
-            larvitar.resetViewports(["viewer"]);
           });
         }
       }
@@ -630,7 +617,6 @@ larvitar
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
             hideSpinner(); // Hide the spinner when all files are processed
-            larvitar.resetViewports(["viewer"]);
           });
         }
       }

--- a/docs/examples/dsa.html
+++ b/docs/examples/dsa.html
@@ -64,7 +64,7 @@ let manager = larvitar.getImageManager();
 let multiFrameSerie = manager[seriesId];
 
 let frameId = 0;
-await larvitar.renderImage(multiFrameSerie, "viewer", frameId);
+await larvitar.renderImage(multiFrameSerie, "viewer", {defaultProps: { sliceNumber: frameId }});
 
 larvitar.addDefaultTools();
 larvitar.setToolActive("Wwwc");
@@ -212,7 +212,9 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
         let multiFrameSerie = manager[seriesId];
 
         let frameId = 0;
-        await larvitar.renderImage(multiFrameSerie, "viewer", frameId);
+        await larvitar.renderImage(multiFrameSerie, "viewer", {
+          defaultProps: { sliceNumber: frameId }
+        });
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
 
@@ -256,17 +258,23 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
             case 49: // 1
               // standard Mode
               larvitar.store.setDSAEnabled(["viewer"], false);
-              larvitar.updateImage(multiFrameSerie, "viewer", frameId);
+              larvitar.renderImage(multiFrameSerie, "viewer", {
+                defaultProps: { sliceNumber: frameId }
+              });
               break;
             case 50: // 2
               // DSA Mode
               larvitar.store.setDSAEnabled(["viewer"], true);
-              larvitar.updateImage(multiFrameSerie, "viewer", frameId);
+              larvitar.renderImage(multiFrameSerie, "viewer", {
+                defaultProps: { sliceNumber: frameId }
+              });
               break;
             case 51: // 3
               // async function
               larvitar.loadAndCacheDsaImageStack(multiFrameSerie, true);
-              larvitar.updateImage(multiFrameSerie, "viewer", frameId);
+              larvitar.renderImage(multiFrameSerie, "viewer", {
+                defaultProps: { sliceNumber: frameId }
+              });
               larvitar.redrawImage("viewer");
               break;
             case 119: // W
@@ -324,12 +332,9 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
                     frameId == multiFrameSerie.numberOfFrames - 1
                       ? 0
                       : frameId + 1;
-                  larvitar.updateImage(
-                    multiFrameSerie,
-                    "viewer",
-                    frameId,
-                    false
-                  );
+                  larvitar.renderImage(multiFrameSerie, "viewer", {
+                    defaultProps: { sliceNumber: frameId }
+                  });
                   document.getElementById("image-time").innerText =
                     "Current Frame: " +
                     parseInt(frameId + 1) +

--- a/docs/examples/ecg.html
+++ b/docs/examples/ecg.html
@@ -70,7 +70,7 @@ async function renderSerie() {
   }
 
   // Render the first frame
-  await larvitar.renderImage(multiFrameSerie, "viewer", frameId);
+  await larvitar.renderImage(multiFrameSerie, "viewer", {defaultProps: { sliceNumber: frameId }});
   larvitar.addDefaultTools();
   larvitar.setToolActive("StackScroll");
 
@@ -88,7 +88,7 @@ async function renderSerie() {
     frameId = endLoop ? 0 : frameId + 1;
 
     let series = larvitar.getSeriesDataFromLarvitarManager(seriesId);
-    larvitar.updateImage(series, "viewer", frameId, true);
+    larvitar.renderImage(series, "viewer", {cached: true, defaultProps: { sliceNumber: frameId }});
     larvitar.updateStackToolState("viewer", frameId);
 
     if (updateECG) {
@@ -264,7 +264,9 @@ async function renderSerie() {
         if (multiFrameSerie.waveform) {
           larvitar.parseECG(seriesId, manager[seriesId].dataSet, "x50003000");
         }
-        await larvitar.renderImage(multiFrameSerie, "viewer", frameId);
+        await larvitar.renderImage(multiFrameSerie, "viewer", {
+          defaultProps: { sliceNumber: frameId }
+        });
         hideSpinner();
         const t1 = performance.now();
         larvitar.logger.debug(
@@ -296,7 +298,10 @@ async function renderSerie() {
           endLoop = frameId == numberOfFrames - 1 ? true : false;
           let series = larvitar.getDataFromImageManager(seriesId);
           frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
-          larvitar.updateImage(series, "viewer", frameId, true);
+          larvitar.renderImage(series, "viewer", {
+            cached: true,
+            defaultProps: { sliceNumber: frameId }
+          });
           larvitar.updateStackToolState("viewer", frameId);
           document.getElementById("image-time").innerText =
             "Current Frame: " + parseInt(frameId + 1) + " of " + numberOfFrames;
@@ -418,19 +423,23 @@ async function renderSerie() {
               animationId = setInterval(function () {
                 let series = larvitar.getDataFromImageManager(seriesId);
                 frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
-                larvitar.updateImage(series, "viewer", frameId, false);
+                larvitar.renderImage(series, "viewer", {
+                  defaultProps: { sliceNumber: frameId }
+                });
                 larvitar.updateStackToolState("viewer", frameId);
                 document.getElementById("image-time").innerText =
                   "Current Frame: " +
                   parseInt(frameId + 1) +
                   " of " +
                   numberOfFrames;
-                larvitar.updateECGMarker(
-                  trace_data,
-                  frameId,
-                  numberOfFrames,
-                  "ecg"
-                );
+                if (updateECG) {
+                  larvitar.updateECGMarker(
+                    trace_data,
+                    frameId,
+                    numberOfFrames,
+                    "ecg"
+                  );
+                }
               }, frameRate);
             } else {
               clearInterval(animationId);

--- a/docs/examples/multiframe.html
+++ b/docs/examples/multiframe.html
@@ -80,7 +80,7 @@
   animationId = setInterval(function () {
     let series = larvitar.getDataFromImageManager(seriesId);
     frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
-    larvitar.updateImage(series, "viewer", frameId, true);
+    larvitar.renderImage(series, "viewer", {cached: true, defaultProps: { sliceNumber: frameId }});
   }, frameRate);
 `;
 
@@ -260,7 +260,10 @@
         let multiFrameSerie = manager[seriesId];
 
         let frameId = 0;
-        await larvitar.renderImage(multiFrameSerie, "viewer", frameId);
+        await larvitar.renderImage(multiFrameSerie, "viewer", {
+          cached: true,
+          defaultProps: { sliceNumber: frameId }
+        });
         hideSpinner();
         const t1 = performance.now();
         larvitar.logger.debug(
@@ -289,7 +292,10 @@
         animationId = setInterval(function () {
           let series = larvitar.getDataFromImageManager(seriesId);
           frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
-          larvitar.updateImage(series, "viewer", frameId, true);
+          larvitar.renderImage(multiFrameSerie, "viewer", {
+            cached: true,
+            defaultProps: { sliceNumber: frameId }
+          });
 
           document.getElementById("image-time").innerText =
             "Current Frame: " + parseInt(frameId + 1) + " of " + numberOfFrames;
@@ -327,7 +333,10 @@
               animationId = setInterval(function () {
                 let series = larvitar.getDataFromImageManager(seriesId);
                 frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
-                larvitar.updateImage(series, "viewer", frameId, false);
+                larvitar.renderImage(multiFrameSerie, "viewer", {
+                  cached: true,
+                  defaultProps: { sliceNumber: frameId }
+                });
 
                 document.getElementById("image-time").innerText =
                   "Current Frame: " +

--- a/docs/examples/singleFrame.html
+++ b/docs/examples/singleFrame.html
@@ -307,12 +307,10 @@
                 endLoop = frameId == numberOfFrames - 1 ? true : false;
                 const imageId = dicomSerie.imageIds[frameId];
                 const currentFrameId = imageId ? frameId : frameId - 1;
-                larvitar.updateImage(
-                  dicomSerie,
-                  canvasId,
-                  currentFrameId,
-                  true
-                );
+                larvitar.renderImage(dicomSerie, canvasId, {
+                  cached: true,
+                  defaultProps: { sliceNumber: currentFrameId }
+                });
                 frameId =
                   currentFrameId == numberOfFrames - 1 ? 0 : currentFrameId + 1;
                 if (endLoop) {

--- a/imaging/loaders/dsaImageLoader.ts
+++ b/imaging/loaders/dsaImageLoader.ts
@@ -63,8 +63,7 @@ export const loadDsaImage: ImageLoader = function (imageId: string): any {
  * Populate the DSA imageIds for a given seriesId
  * @export
  * @function populateDsaImageIds
- * @param {String} seriesId - SeriesId tag
- * @param {Object} serie - parsed serie object
+ * @param {string} uniqueUID - The unique identifier for the series
  */
 export const populateDsaImageIds = function (uniqueUID: string) {
   let t0 = performance.now();

--- a/imaging/postProcessing/applyDSA.ts
+++ b/imaging/postProcessing/applyDSA.ts
@@ -9,7 +9,7 @@ import cornerstone, { Image } from "cornerstone-core";
 // internal libraries
 import { logger } from "../../logger";
 import { DSA, Series } from "../types";
-import { updateImage, redrawImage } from "../imageRendering";
+import { renderImage, redrawImage } from "../imageRendering";
 import store from "../imageStore";
 
 /*
@@ -73,7 +73,10 @@ export const applyDSAShift = function (
   cornerstone.imageCache.removeImageLoadObject(imageId);
 
   // update image
-  updateImage(multiFrameSerie, elementId, frameId, true);
+  renderImage(multiFrameSerie, elementId, {
+    cached: true,
+    defaultProps: { sliceNumber: frameId }
+  });
   redrawImage(elementId);
 
   const t1 = performance.now();

--- a/imaging/tools/custom/gspsUtils/maskUtils.ts
+++ b/imaging/tools/custom/gspsUtils/maskUtils.ts
@@ -8,7 +8,7 @@ import {
 import { convertCIELabToRGBWithRefs } from "./genericDrawingUtils";
 import * as csTools from "cornerstone-tools";
 import { ViewportComplete } from "../../types";
-import { redrawImage, updateImage } from "../../../imageRendering";
+import { redrawImage, renderImage } from "../../../imageRendering";
 import imageStore from "../../../imageStore";
 const getNewContext = csTools.importInternal("drawing/getNewContext");
 import { logger } from "../../../../logger";
@@ -113,10 +113,10 @@ export function retrieveDisplayShutter(
  *
  * @returns {void}
  */
-export function applyMask(serie: Series, element: HTMLElement) {
+export function applyMask(serie: Series, element: HTMLElement): void {
   if (serie.isMultiframe) {
     const frameId = imageStore.get(["viewports", "viewer", "sliceId"]);
     imageStore.setDSAEnabled(element.id, true);
-    updateImage(serie, element.id, frameId, false);
+    renderImage(serie, element.id, { defaultProps: { sliceNumber: frameId } });
   }
 }

--- a/imaging/tools/interaction.ts
+++ b/imaging/tools/interaction.ts
@@ -254,6 +254,7 @@ export const toggleMouseToolsListeners = function (
   }
 
   if (disable) {
+    console.debug("remove mouse tools listeners");
     element.removeEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
     element.removeEventListener(
       "cornerstonetoolsstackscroll",
@@ -262,6 +263,7 @@ export const toggleMouseToolsListeners = function (
     return;
   }
 
+  console.debug("add mouse tools listeners");
   element.addEventListener("cornerstonetoolsmousedrag", mouseMoveHandler);
   element.addEventListener("cornerstonetoolsstackscroll", mouseWheelHandler);
 };

--- a/imaging/tools/main.ts
+++ b/imaging/tools/main.ts
@@ -56,7 +56,7 @@ const initializeCSTools = function (
  * @function csToolsCreateStack
  * @param {HTMLElement} element - The target html element.
  * @param {Array?} imageIds - Stack image ids.
- * @param {String} currentImageId - The current image id.
+ * @param {number?} currentImageIndex - The current image id.
  */
 const csToolsCreateStack = function (
   element: HTMLElement,

--- a/imaging/types.d.ts
+++ b/imaging/types.d.ts
@@ -61,7 +61,7 @@ export type StoreViewport = {
   isPDF: boolean;
   waveform: boolean;
   dsa: boolean;
-  imageIndex?: number; // TODO CAN BE DEPRECATED?
+  imageIndex?: number;
   imageId?: string;
   numberOfSlices?: number;
   numberOfTemporalPositions?: number;

--- a/imaging/waveforms/ecg.ts
+++ b/imaging/waveforms/ecg.ts
@@ -8,7 +8,7 @@ import Plotly, { Datum } from "plotly.js-dist-min";
 
 // internal libraries
 import { NrrdSeries, Series } from "../types";
-import { updateImage } from "../imageRendering";
+import { renderImage } from "../imageRendering";
 import store from "../imageStore";
 import { getDataFromImageManager } from "../imageManagers";
 import { updateStackToolState } from "../imageTools";
@@ -181,7 +181,9 @@ export const syncECGFrame = function (
       const series: Series | NrrdSeries | null =
         getDataFromImageManager(seriesId);
       if (series) {
-        updateImage(series as Series, canvasId, frameId, false);
+        renderImage(series as Series, canvasId, {
+          defaultProps: { sliceNumber: frameId }
+        });
         updateStackToolState(canvasId, frameId);
       }
     });

--- a/index.ts
+++ b/index.ts
@@ -19,10 +19,14 @@ function warnDeprecation(originalName: string, aliasName: string) {
 function createAliasWithWarning(
   originalFunction: Function,
   originalName: string,
-  aliasName: string
+  aliasName: string,
+  onlyWarn: boolean = false
 ) {
   return function (...args: any) {
     warnDeprecation(originalName, aliasName);
+    if (onlyWarn) {
+      return;
+    }
     return originalFunction(...args);
   };
 }
@@ -141,7 +145,6 @@ import {
   unloadViewport,
   resizeViewport,
   renderImage,
-  updateImage,
   redrawImage,
   resetViewports,
   updateViewportData,
@@ -383,7 +386,6 @@ export {
   unloadViewport,
   resizeViewport,
   renderImage,
-  updateImage,
   redrawImage,
   resetViewports,
   updateViewportData,
@@ -588,4 +590,11 @@ export const getFileImageId = createAliasWithWarning(
   getDataFromFileManager,
   "getDataFromFileManager",
   "getFileImageId"
+);
+
+export const updateImage = createAliasWithWarning(
+  renderImage,
+  "renderImage",
+  "updateImage",
+  true
 );

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
**Modifiche principali:**

- Deprecazione di updateImage: Il metodo updateImage è stato contrassegnato come deprecato e non dovrebbe più essere utilizzato nelle implementazioni future.​

- Utilizzo di renderImage: Tutte le funzionalità precedentemente gestite da updateImage sono ora centralizzate in renderImage, che diventa l'unico metodo per il rendering delle immagini.​

**Implicazioni per gli sviluppatori:**

- Aggiornamento del codice: È consigliato sostituire tutte le chiamate a updateImage con renderImage per garantire la compatibilità con le versioni future della libreria.​

- Uniformità dell'API: Questa modifica favorisce una maggiore coerenza nell'utilizzo dell'API, riducendo la curva di apprendimento e semplificando la manutenzione del codice.​

In conclusione, questa Pull Request rappresenta un passo verso la semplificazione e l'ottimizzazione dell'API di Larvitar, incoraggiando l'adozione di pratiche più uniformi e moderne nel rendering delle immagini.