### PR TITLE
Fix examples

### DIFF
--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -106,8 +106,13 @@ larvitar
     <div class="row h-100">
       <div
         id="viewer"
-        class="col-12 h-100"
+        class="col-8 h-100"
         style="background-color: black"
+      ></div>
+      <div
+        id="plot-viewer"
+        class="col-4"
+        style="background-color: rgb(0, 0, 0)"
       ></div>
       <p style="position: absolute; color: white">
         <b>Left Mouse Button:</b> Press "t" to cycle through tools
@@ -118,14 +123,14 @@ larvitar
       <p style="position: absolute; top: 40px; color: white">
         <b>Right Mouse Button:</b> drag >> Zoom || drag + Ctrl >> Pan
       </p>
+      <p id="info" style="position: absolute; top: 60px; color: white"></p>
       <button
         id="showCodeBtn"
         class="open-button"
-        style="position: absolute; top: 70px"
+        style="position: absolute; top: 90px"
       >
         Show Code
       </button>
-
       <!-- Modal -->
       <div
         class="modal fade"
@@ -277,7 +282,8 @@ larvitar
             "FreehandScissors",
             "CircleScissors",
             "CorrectionScissors",
-            "PolylineScissors"
+            "PolylineScissors",
+            "Gsps"
           ];
 
           // Filter out segmentation tools
@@ -291,6 +297,15 @@ larvitar
           larvitar.setToolActive(tool, { mouseButtonMask: 1 });
           document.getElementById("active-tool").innerText =
             "Active Tool: " + tool;
+          const info = document.getElementById("info");
+          if (tool === "LengthPlot") {
+            larvitar.clearSegmentationState();
+            info.style.display = "block";
+            info.innerHTML =
+              "<b>shift+mouse wheel to change lines offset</b><br />";
+          } else {
+            info.style.display = "none";
+          }
         }
       };
     </script>

--- a/docs/examples/gsps.html
+++ b/docs/examples/gsps.html
@@ -183,6 +183,7 @@ larvitar
         } else {
           larvitar.setToolEnabled("Gsps");
         }
+        larvitar.setToolActive("Wwwc");
         isGspsActive = !isGspsActive;
       }
       toggleGsps.addEventListener("click", toggleButton);
@@ -237,6 +238,7 @@ larvitar
               hideSpinner(); // Hide the spinner when all files are processed
               larvitar.addDefaultTools();
               larvitar.setToolEnabled("Gsps");
+              larvitar.setToolActive("Wwwc");
             });
           })
           .catch(err => larvitar.logger.error(err));

--- a/docs/examples/watershedSegmentationTool.html
+++ b/docs/examples/watershedSegmentationTool.html
@@ -393,40 +393,15 @@ larvitar
 
       async function renderSerie() {
         larvitar.resetImageManager();
-        larvitar
-          .readFiles(demoFiles)
-          .then(seriesStack => {
-            larvitar.logger.debug(seriesStack);
-            // render the first series of the study
-            let seriesId = Object.keys(seriesStack)[0];
-            let serie = seriesStack[seriesId];
-            larvitar.renderImage(serie, "viewer").then(() => {
-              hideSpinner();
-              larvitar.logger.debug("Image has been rendered");
-            });
-            // optionally cache the series
-            larvitar.populateImageManager(seriesId, serie);
-
-            larvitar
-              .cacheImages(serie, function (resp) {
-                if (resp.loading == 100) {
-                  let cache = larvitar.cornerstone.imageCache;
-                  larvitar.logger.debug(
-                    "Cache size: ",
-                    cache.getCacheInfo().cacheSizeInBytes / 1e6,
-                    "Mb"
-                  );
-                }
-              })
-              .then(() => {
-                larvitar.logger.debug(
-                  "Cache has been loaded. Calling loadMasks."
-                );
-                larvitar.addDefaultTools();
-                loadMasks();
-              });
-          })
-          .catch(err => larvitar.logger.error(err));
+        const seriesStack = await larvitar.readFiles(demoFiles);
+        // render the first series of the study
+        let seriesId = Object.keys(seriesStack)[0];
+        let serie = seriesStack[seriesId];
+        await larvitar.renderImage(serie, "viewer");
+        hideSpinner();
+        larvitar.logger.debug("Image has been rendered");
+        larvitar.addDefaultTools();
+        await loadMasks();
       }
 
       async function loadMasks() {

--- a/imaging/tools/custom/gspsTool.ts
+++ b/imaging/tools/custom/gspsTool.ts
@@ -82,6 +82,7 @@ export default class GspsTool extends BaseTool {
     if (activeElement) {
       const image = activeElement.image;
       const viewport = cornerstone.getViewport(element) as Viewport;
+      this.originalViewport = structuredClone(viewport);
 
       const { manager, seriesId } = this.retrieveLarvitarManager(
         image!.imageId
@@ -138,6 +139,7 @@ export default class GspsTool extends BaseTool {
               graphicGroups
             );
             cornerstone.setViewport(element, viewport);
+            this.gspsViewport = structuredClone(viewport);
           } else {
             this.gspsMetadata = undefined;
           }
@@ -255,7 +257,20 @@ export default class GspsTool extends BaseTool {
   }
 
   resetViewportToDefault(element: HTMLElement) {
-    resetViewports([element.id]);
+    const isZoomed = this.gspsViewport.scale !== this.originalViewport.scale;
+
+    const isContrastModified =
+      this.gspsViewport.voi.windowCenter !==
+        this.originalViewport.voi.windowCenter ||
+      this.gspsViewport.voi.windowWidth !==
+        this.originalViewport.voi.windowWidth;
+
+    if (isZoomed) {
+      resetViewports([element.id], ["zoom"]);
+    }
+    if (isContrastModified) {
+      resetViewports([element.id], ["contrast"]);
+    }
     const enabledElement = getEnabledElement(element) as any as {
       viewport: ViewportComplete;
     };
@@ -270,27 +285,29 @@ export default class GspsTool extends BaseTool {
     try {
       const activeElement = cornerstone.getEnabledElement(element);
 
-      // Return a promise that resolves when the image becomes available
-      return new Promise((resolve, reject) => {
-        const checkImageAvailability = setInterval(() => {
-          if (activeElement.image !== undefined) {
-            clearInterval(checkImageAvailability);
-            logger.debug("Image is now available", activeElement.image);
-            resolve(activeElement); // Resolve the promise with the activeElement
-          } else {
-            logger.debug("Image not yet available, continuing to poll...");
-          }
-        }, 100); // Poll every 100ms
+      // If image is already available, resolve immediately
+      if (activeElement.image !== undefined) {
+        return Promise.resolve(activeElement);
+      }
 
-        // Reject the promise if needed, e.g., after a timeout
+      // Otherwise wait for the image to load
+      return new Promise((resolve, reject) => {
+        // When image is rendered
+        element.addEventListener(
+          "cornerstoneimagerendered",
+          () => {
+            resolve(cornerstone.getEnabledElement(element));
+          },
+          { once: true }
+        );
+
         setTimeout(() => {
-          clearInterval(checkImageAvailability);
           reject(new Error("Image did not become available in time"));
-        }, 5000); // 5 seconds timeout
+        }, 5000);
       });
     } catch (error) {
       logger.error("Error processing element:", error);
-      throw error; // Rethrow the error
+      throw error;
     }
   }
 

--- a/imaging/tools/custom/gspsUtils/annotationAndOverlayRetrievalUtils.ts
+++ b/imaging/tools/custom/gspsUtils/annotationAndOverlayRetrievalUtils.ts
@@ -386,7 +386,6 @@ export function retrieveOverlayToolData(
   const shutterOverlayGroup = metadata.x00181623; // Shutter Overlay Group
   // Guard clause for undefined shutterOverlayGroup
   if (!shutterOverlayGroup) {
-    logger.warn("Shutter overlay group is undefined.");
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.1.0",
+  "version": "3.2.1",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
- Fixed the LengthPlotTool example to properly update the offset using the mouse wheel while holding Shift.
- Enhanced the defaultTools example by adding a plot and info description for better clarity.
- Resolved issues in the Watershed example by ensuring correct rendering and adding masks to the viewport.