### PR TITLE
fix GSPS tool 

### DIFF
--- a/docs/examples/gsps.html
+++ b/docs/examples/gsps.html
@@ -183,6 +183,7 @@ larvitar
         } else {
           larvitar.setToolEnabled("Gsps");
         }
+        larvitar.setToolActive("Wwwc");
         isGspsActive = !isGspsActive;
       }
       toggleGsps.addEventListener("click", toggleButton);
@@ -237,6 +238,7 @@ larvitar
               hideSpinner(); // Hide the spinner when all files are processed
               larvitar.addDefaultTools();
               larvitar.setToolEnabled("Gsps");
+              larvitar.setToolActive("Wwwc");
             });
           })
           .catch(err => larvitar.logger.error(err));

--- a/imaging/tools/custom/gspsTool.ts
+++ b/imaging/tools/custom/gspsTool.ts
@@ -82,6 +82,7 @@ export default class GspsTool extends BaseTool {
     if (activeElement) {
       const image = activeElement.image;
       const viewport = cornerstone.getViewport(element) as Viewport;
+      this.originalViewport = structuredClone(viewport);
 
       const { manager, seriesId } = this.retrieveLarvitarManager(
         image!.imageId
@@ -138,6 +139,7 @@ export default class GspsTool extends BaseTool {
               graphicGroups
             );
             cornerstone.setViewport(element, viewport);
+            this.gspsViewport = structuredClone(viewport);
           } else {
             this.gspsMetadata = undefined;
           }
@@ -255,7 +257,20 @@ export default class GspsTool extends BaseTool {
   }
 
   resetViewportToDefault(element: HTMLElement) {
-    resetViewports([element.id]);
+    const isZoomed = this.gspsViewport.scale !== this.originalViewport.scale;
+
+    const isContrastModified =
+      this.gspsViewport.voi.windowCenter !==
+        this.originalViewport.voi.windowCenter ||
+      this.gspsViewport.voi.windowWidth !==
+        this.originalViewport.voi.windowWidth;
+
+    if (isZoomed) {
+      resetViewports([element.id], ["zoom"]);
+    }
+    if (isContrastModified) {
+      resetViewports([element.id], ["contrast"]);
+    }
     const enabledElement = getEnabledElement(element) as any as {
       viewport: ViewportComplete;
     };
@@ -270,27 +285,29 @@ export default class GspsTool extends BaseTool {
     try {
       const activeElement = cornerstone.getEnabledElement(element);
 
-      // Return a promise that resolves when the image becomes available
-      return new Promise((resolve, reject) => {
-        const checkImageAvailability = setInterval(() => {
-          if (activeElement.image !== undefined) {
-            clearInterval(checkImageAvailability);
-            logger.debug("Image is now available", activeElement.image);
-            resolve(activeElement); // Resolve the promise with the activeElement
-          } else {
-            logger.debug("Image not yet available, continuing to poll...");
-          }
-        }, 100); // Poll every 100ms
+      // If image is already available, resolve immediately
+      if (activeElement.image !== undefined) {
+        return Promise.resolve(activeElement);
+      }
 
-        // Reject the promise if needed, e.g., after a timeout
+      // Otherwise wait for the image to load
+      return new Promise((resolve, reject) => {
+        // When image is rendered
+        element.addEventListener(
+          "cornerstoneimagerendered",
+          () => {
+            resolve(cornerstone.getEnabledElement(element));
+          },
+          { once: true }
+        );
+
         setTimeout(() => {
-          clearInterval(checkImageAvailability);
           reject(new Error("Image did not become available in time"));
-        }, 5000); // 5 seconds timeout
+        }, 5000);
       });
     } catch (error) {
       logger.error("Error processing element:", error);
-      throw error; // Rethrow the error
+      throw error;
     }
   }
 

--- a/imaging/tools/custom/gspsUtils/annotationAndOverlayRetrievalUtils.ts
+++ b/imaging/tools/custom/gspsUtils/annotationAndOverlayRetrievalUtils.ts
@@ -386,7 +386,6 @@ export function retrieveOverlayToolData(
   const shutterOverlayGroup = metadata.x00181623; // Shutter Overlay Group
   // Guard clause for undefined shutterOverlayGroup
   if (!shutterOverlayGroup) {
-    logger.warn("Shutter overlay group is undefined.");
     return;
   }
 


### PR DESCRIPTION
 **Improved Image Loading Performance**

- The `activeElement.image` polling process has been optimized to avoid blocking execution: Instead of using setInterval, we now wait asynchronously for the image to be available (using `cornerstoneimagerendered `event), significantly reducing load time.

**Fixed Missing Icon for Active WWWC Tool**
- The UI now correctly displays the tool icon when the Window Width/Level (WWWC) tool is active.

**Preserved Contrast Values When Toggling GSPS**
- Previously, toggling GSPS off would reset contrast values. Now, user-selected contrast and zoom values are maintained and only gsps values are reset.

**Removed Unnecessary Warning: "Shutter overlay group is undefined."**
