### PR TITLE
feat: new rendering options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.3.0] - 2025-03-21
+
+🚀 Key Changes:
+
+- `renderImage` now accepts an optional `RenderProps` object for more flexible rendering options.
+
+**New Feature:** Added support for advanced rendering options, such as `scale`, `rotation`, `voi`, and `colormap`, directly through the `RenderProps` object.  
+
+**Deprecated parameter removed:** The `defaultProps` parameter has been replaced by the new `RenderProps` object.
 
 ## [3.2.0] - 2025-03-17
 

--- a/docs/api/rendering.md
+++ b/docs/api/rendering.md
@@ -96,14 +96,14 @@ All properties are optional.
 | `default.translation` | `translation`| Default translation vector for the image.        |
 | `default.voi`         | `contrast`   | Default windowing parameters for the image.      |
 
-#### `Contrast` Interface
+#### `contrast` Interface
 
 | Property              | Type         | Description                                |
 |-----------------------|--------------|--------------------------------------------|
 | `windowWidth`         | `number`     | The window width for the image.            |
 | `windowCenter`        | `number`     | The window center for the image.           |
 
-#### `Translation` Interface
+#### `translation` Interface
 
 | Property     | Type      | Description                       |
 |--------------|-----------|-----------------------------------|

--- a/docs/examples/4d.html
+++ b/docs/examples/4d.html
@@ -266,7 +266,7 @@ larvitar
           let multiFrameSerie = manager[seriesId];
           let frameId = 0;
           larvitar
-            .renderImage(multiFrameSerie, "viewer", frameId)
+            .renderImage(multiFrameSerie, "viewer", { imageIndex: frameId })
             .then(() => {
               larvitar.logger.debug("Image has been rendered");
               hideSpinner();
@@ -301,7 +301,7 @@ larvitar
                           : sliceId + 1;
 
                       larvitar.renderImage(serie, "viewer", {
-                        defaultProps: { sliceNumber: sliceId }
+                        imageIndex: sliceId
                       });
                       changeStamps();
                     }, 100);

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -544,9 +544,25 @@ larvitar
             let seriesId = Object.keys(seriesStack)[0];
             let manager = larvitar.getImageManager();
             let serie = manager[seriesId];
+
+            // const options = {
+            //   imageIndex: 3,
+            //   scale: 5,
+            //   rotation: 40,
+            //   translation: {
+            //     x: 5,
+            //     y: 5
+            //   },
+            //   voi: {
+            //     windowCenter: 40,
+            //     windowWidth: 400
+            //   }
+            // };
+
             larvitar.renderImage(serie, "viewer").then(() => {
               larvitar.logger.debug("Image has been rendered");
               hideSpinner(); // Hide the spinner when all files are processed
+              larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
               larvitar.addDefaultTools();
               larvitar.setToolActive("Wwwc");
             });
@@ -596,6 +612,7 @@ larvitar
           const serie = stack[newSeriesId];
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
+            larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
             hideSpinner(); // Hide the spinner when all files are processed
           });
         }
@@ -616,6 +633,7 @@ larvitar
           const serie = stack[newSeriesId];
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
+            larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
             hideSpinner(); // Hide the spinner when all files are processed
           });
         }

--- a/docs/examples/dsa.html
+++ b/docs/examples/dsa.html
@@ -89,7 +89,7 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
       });
     </script>
 
-    <title>Larvitar - Basic rendering example</title>
+    <title>Larvitar - Digital Subtraction example</title>
   </head>
 
   <body class="h-100" style="background-color: #000000">

--- a/docs/examples/dsa.html
+++ b/docs/examples/dsa.html
@@ -64,7 +64,7 @@ let manager = larvitar.getImageManager();
 let multiFrameSerie = manager[seriesId];
 
 let frameId = 0;
-await larvitar.renderImage(multiFrameSerie, "viewer", {defaultProps: { sliceNumber: frameId }});
+await larvitar.renderImage(multiFrameSerie, "viewer", { imageIndex: frameId });
 
 larvitar.addDefaultTools();
 larvitar.setToolActive("Wwwc");
@@ -213,7 +213,7 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
 
         let frameId = 0;
         await larvitar.renderImage(multiFrameSerie, "viewer", {
-          defaultProps: { sliceNumber: frameId }
+          imageIndex: frameId
         });
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
@@ -259,21 +259,21 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
               // standard Mode
               larvitar.store.setDSAEnabled(["viewer"], false);
               larvitar.renderImage(multiFrameSerie, "viewer", {
-                defaultProps: { sliceNumber: frameId }
+                imageIndex: frameId
               });
               break;
             case 50: // 2
               // DSA Mode
               larvitar.store.setDSAEnabled(["viewer"], true);
               larvitar.renderImage(multiFrameSerie, "viewer", {
-                defaultProps: { sliceNumber: frameId }
+                imageIndex: frameId
               });
               break;
             case 51: // 3
               // async function
               larvitar.loadAndCacheDsaImageStack(multiFrameSerie, true);
               larvitar.renderImage(multiFrameSerie, "viewer", {
-                defaultProps: { sliceNumber: frameId }
+                imageIndex: frameId
               });
               larvitar.redrawImage("viewer");
               break;
@@ -333,7 +333,7 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
                       ? 0
                       : frameId + 1;
                   larvitar.renderImage(multiFrameSerie, "viewer", {
-                    defaultProps: { sliceNumber: frameId }
+                    imageIndex: frameId
                   });
                   document.getElementById("image-time").innerText =
                     "Current Frame: " +

--- a/docs/examples/ecg.html
+++ b/docs/examples/ecg.html
@@ -158,7 +158,7 @@ async function renderSerie() {
       ></p>
       <p id="fps" style="position: absolute; top: 60px; color: white"></p>
       <p style="position: absolute; top: 80px; color: white">
-        Press "+/-" to change frame rate
+        Press "+/-" to change loop time
       </p>
       <p
         id="loop-time"

--- a/docs/examples/ecg.html
+++ b/docs/examples/ecg.html
@@ -70,7 +70,7 @@ async function renderSerie() {
   }
 
   // Render the first frame
-  await larvitar.renderImage(multiFrameSerie, "viewer", {defaultProps: { sliceNumber: frameId }});
+  await larvitar.renderImage(multiFrameSerie, "viewer", { imageIndex: frameId });
   larvitar.addDefaultTools();
   larvitar.setToolActive("StackScroll");
 
@@ -88,7 +88,7 @@ async function renderSerie() {
     frameId = endLoop ? 0 : frameId + 1;
 
     let series = larvitar.getSeriesDataFromLarvitarManager(seriesId);
-    larvitar.renderImage(series, "viewer", {cached: true, defaultProps: { sliceNumber: frameId }});
+    larvitar.renderImage(series, "viewer", {cached: true, imageIndex: frameId });
     larvitar.updateStackToolState("viewer", frameId);
 
     if (updateECG) {
@@ -265,7 +265,7 @@ async function renderSerie() {
           larvitar.parseECG(seriesId, manager[seriesId].dataSet, "x50003000");
         }
         await larvitar.renderImage(multiFrameSerie, "viewer", {
-          defaultProps: { sliceNumber: frameId }
+          imageIndex: frameId
         });
         hideSpinner();
         const t1 = performance.now();
@@ -300,7 +300,7 @@ async function renderSerie() {
           frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
           larvitar.renderImage(series, "viewer", {
             cached: true,
-            defaultProps: { sliceNumber: frameId }
+            imageIndex: frameId
           });
           larvitar.updateStackToolState("viewer", frameId);
           document.getElementById("image-time").innerText =
@@ -424,7 +424,7 @@ async function renderSerie() {
                 let series = larvitar.getDataFromImageManager(seriesId);
                 frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
                 larvitar.renderImage(series, "viewer", {
-                  defaultProps: { sliceNumber: frameId }
+                  imageIndex: frameId
                 });
                 larvitar.updateStackToolState("viewer", frameId);
                 document.getElementById("image-time").innerText =

--- a/docs/examples/multiframe.html
+++ b/docs/examples/multiframe.html
@@ -63,7 +63,7 @@
   let multiFrameSerie = manager[seriesId];
 
   let frameId = 0;
-  await larvitar.renderImage(multiFrameSerie, "viewer", frameId);
+  await larvitar.renderImage(multiFrameSerie, "viewer", {imageIndex: frameId});
   const t1 = performance.now();
   larvitar.addDefaultTools();
   larvitar.setToolActive("StackScroll");
@@ -80,7 +80,7 @@
   animationId = setInterval(function () {
     let series = larvitar.getDataFromImageManager(seriesId);
     frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
-    larvitar.renderImage(series, "viewer", {cached: true, defaultProps: { sliceNumber: frameId }});
+    larvitar.renderImage(series, "viewer", {cached: true, imageIndex: frameId });
   }, frameRate);
 `;
 
@@ -262,7 +262,7 @@
         let frameId = 0;
         await larvitar.renderImage(multiFrameSerie, "viewer", {
           cached: true,
-          defaultProps: { sliceNumber: frameId }
+          imageIndex: frameId
         });
         hideSpinner();
         const t1 = performance.now();
@@ -294,7 +294,7 @@
           frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
           larvitar.renderImage(multiFrameSerie, "viewer", {
             cached: true,
-            defaultProps: { sliceNumber: frameId }
+            imageIndex: frameId
           });
 
           document.getElementById("image-time").innerText =
@@ -335,7 +335,7 @@
                 frameId = frameId == numberOfFrames - 1 ? 0 : frameId + 1;
                 larvitar.renderImage(multiFrameSerie, "viewer", {
                   cached: true,
-                  defaultProps: { sliceNumber: frameId }
+                  imageIndex: frameId
                 });
 
                 document.getElementById("image-time").innerText =

--- a/docs/examples/singleFrame.html
+++ b/docs/examples/singleFrame.html
@@ -265,7 +265,7 @@
         larvitar
           .renderImage(dicomSerie, canvasId, {
             cached: true,
-            defaultProps: { sliceNumber: 0 }
+            imageIndex: 0
           })
           .then(() => {
             const t1 = performance.now();
@@ -309,7 +309,7 @@
                 const currentFrameId = imageId ? frameId : frameId - 1;
                 larvitar.renderImage(dicomSerie, canvasId, {
                   cached: true,
-                  defaultProps: { sliceNumber: currentFrameId }
+                  imageIndex: currentFrameId
                 });
                 frameId =
                   currentFrameId == numberOfFrames - 1 ? 0 : currentFrameId + 1;

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -18,9 +18,9 @@ import { applyColorMap } from "./imageColormaps";
 import { isElement } from "./imageUtils";
 import {
   Instance,
+  RenderProps,
   Series,
   StoreViewport,
-  StoreViewportOptions,
   Viewport
 } from "./types";
 import { DEFAULT_TOOLS } from "./tools/default";
@@ -38,7 +38,7 @@ import { setPixelShift } from "./loaders/dsaImageLoader";
  * disableViewport(elementId)
  * unloadViewport(elementId, seriesId)
  * resizeViewport(elementId)
- * renderImage(series, elementId, defaultProps)
+ * renderImage(series, elementId, remderOptions)
  * redrawImage(elementId)
  * resetViewports([elementIds])
  * updateViewportData(elementId)
@@ -412,7 +412,7 @@ export const renderWebImage = function (
         return;
       }
       cornerstone.displayImage(element, image);
-      csToolsCreateStack(element);
+      csToolsCreateStack(element, [], 0);
       resolve(image);
     });
   });
@@ -486,16 +486,13 @@ export const resizeViewport = function (elementId: string | HTMLElement) {
  * @function renderImage
  * @param {Object} seriesStack - The original series data object
  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
- * @param {Object | undefined} options - Optional properties
+ * @param {RenderProps | undefined} options - Optional properties
  * @return {Promise} Return a promise which will resolve when image is displayed
  */
 export const renderImage = function (
   seriesStack: Series,
   elementId: string | HTMLElement,
-  options?: {
-    defaultProps?: StoreViewportOptions;
-    cached?: boolean;
-  }
+  options?: RenderProps
 ): Promise<true> {
   const t0 = performance.now();
 
@@ -504,9 +501,9 @@ export const renderImage = function (
     ? (elementId as HTMLElement)
     : document.getElementById(elementId as string);
   if (!element) {
-    logger.error("invalid html element: " + elementId);
+    logger.error(`invalid html element: ${elementId}`);
     return new Promise((_, reject) =>
-      reject("invalid html element: " + elementId)
+      reject(`invalid html element: ${elementId}`)
     );
   }
   const id: string = isElement(elementId) ? element.id : (elementId as string);
@@ -522,10 +519,9 @@ export const renderImage = function (
   }
 
   let series = { ...seriesStack };
-  let data: StoreViewport = getSeriesData(
-    series,
-    options && options.defaultProps ? options.defaultProps : {}
-  );
+  const renderOptions = options ? options : {};
+  let data: StoreViewport = getSeriesData(series, renderOptions);
+  logger.debug(`Rendering imageIndex: ${data.imageIndex}`);
 
   if (!data.imageId) {
     logger.warn("error during renderImage: imageId has not been loaded yet.");
@@ -538,7 +534,11 @@ export const renderImage = function (
   // this by default is the uniqueId of the rendered stack
   const storedSeriesUID = store.get(["viewports", id, "seriesUID"]);
   const isSeriesUIDChanged = storedSeriesUID !== data.seriesUID;
-  logger.debug("isSeriesUIDChanged: " + isSeriesUIDChanged);
+  if (isSeriesUIDChanged) {
+    logger.debug(
+      `SeriesUID changed from ${storedSeriesUID} to ${data.seriesUID}`
+    );
+  }
 
   // DSA ALGORITHM OPTIONS
   const dsaEnabled = store.get(["viewports", id, "isDSAEnabled"]);
@@ -547,7 +547,7 @@ export const renderImage = function (
     data.imageId = series.dsa!.imageIds[data.imageIndex!];
     // get the optional custom pixel shift for DSA images
     if (pixelShift !== undefined) {
-      logger.debug("set pixelShift: " + pixelShift);
+      logger.debug(`set pixelShift: ${pixelShift}`);
       setPixelShift(pixelShift);
     }
   }
@@ -567,26 +567,32 @@ export const renderImage = function (
       // load and display one image (imageId)
       loadImageFunction(data.imageId as string).then(function (image) {
         if (!element) {
-          logger.error("invalid html element: " + elementId);
-          reject("invalid html element: " + elementId);
+          logger.error(`invalid html element: ${elementId}`);
+          reject(`invalid html element: ${elementId}`);
           return;
         }
 
+        // display the image on the element
         cornerstone.displayImage(element, image);
+        logger.debug(`Image has been displayed on the element: ${elementId}`);
 
-        if (options && options.cached) {
+        // if cached is true, set the image as cached in the store
+        if (renderOptions.cached === true) {
           setStore(["cached", series.uniqueUID, data.imageId as string, true]);
+          logger.debug("Image has been cached into store");
         }
 
+        // handle the optional layer
         if (series.layer) {
-          // assign the image to its layer and return its id
           series.layer.id = cornerstone.addLayer(
             element,
             image,
             series.layer.options
           );
+          logger.debug("Layer has been added to the element");
         }
 
+        // fit the image to the window with standard scaling
         cornerstone.fitToWindow(element);
 
         // update viewport data with default properties
@@ -597,59 +603,110 @@ export const renderImage = function (
           return;
         }
 
-        if (
-          options &&
-          options.defaultProps &&
-          options &&
-          options.defaultProps.scale !== undefined
-        ) {
-          viewport.scale = options.defaultProps["scale"];
-          cornerstone.setViewport(element, viewport);
+        // set the optional custom zoom
+        if (renderOptions.scale !== undefined) {
+          // store default scale value if not specified
+          if (data.default?.scale === undefined) {
+            data.default!.scale = viewport.scale;
+          }
+          viewport.scale = renderOptions.scale;
+          logger.debug(
+            `updating cornerstone viewport with custom scale value: ${renderOptions.scale}`
+          );
+        }
+        // set the optional custom translation
+        if (renderOptions.translation !== undefined) {
+          // store default translation value if not specified
+          if (data.default?.translation === undefined) {
+            data.default!.translation = data.default!.translation || {
+              x: 0,
+              y: 0
+            };
+            data.default!.translation.x = viewport.translation.x || 0;
+            data.default!.translation.y = viewport.translation.y || 0;
+          }
+          viewport.translation.x = renderOptions.translation.x;
+          viewport.translation.y = renderOptions.translation.y;
+          logger.debug(
+            `updating cornerstone viewport with custom translation values: ${renderOptions.translation.x}, ${renderOptions.translation.y}`
+          );
+        }
+        // set the optional custom rotation
+        if (renderOptions.rotation !== undefined) {
+          // store default rotation value if not specified
+          if (data.default?.rotation === undefined) {
+            data.default!.rotation = viewport.rotation || 0;
+          }
+          viewport.rotation = renderOptions.rotation;
+          logger.debug(
+            `updating cornerstone viewport with custom rotation value: ${renderOptions.rotation}`
+          );
+        }
+        // set the optional custom contrast
+        if (renderOptions.voi !== undefined) {
+          viewport.voi.windowWidth = renderOptions.voi.windowWidth;
+          viewport.voi.windowCenter = renderOptions.voi.windowCenter;
+          logger.debug(
+            `updating cornerstone viewport with custom contrast values: ${renderOptions.voi.windowWidth}, ${renderOptions.voi.windowCenter}`
+          );
         }
 
-        if (
-          options &&
-          options.defaultProps &&
-          options &&
-          options.defaultProps.tr_x !== undefined &&
-          options &&
-          options.defaultProps.tr_y !== undefined
-        ) {
-          viewport.translation.x = options.defaultProps.tr_x;
-          viewport.translation.y = options.defaultProps.tr_y;
-          cornerstone.setViewport(element, viewport);
-        }
-
-        // color maps
-        if (
-          options &&
-          options.defaultProps &&
-          options &&
-          options.defaultProps.colormap &&
-          image.color == false
-        ) {
-          applyColorMap(options.defaultProps["colormap"]);
-        }
-
+        // if seriesUID has changed update the value into the store
         if (isSeriesUIDChanged) {
           setStore(["seriesUID", element.id, data.seriesUID]);
-          viewport.voi.windowWidth =
-            data.default?.voi?.windowWidth || image.windowWidth;
-          viewport.voi.windowCenter =
-            data.default?.voi?.windowCenter || image.windowCenter;
-          logger.debug("updating cornerstone viewport with default values");
-          cornerstone.setViewport(element, viewport);
+          if (renderOptions.scale === undefined) {
+            viewport.scale = data.default?.scale || viewport.scale;
+            logger.debug(
+              "updating cornerstone viewport with default scale value: ",
+              viewport.scale
+            );
+          }
+          if (renderOptions.translation === undefined) {
+            viewport.translation.x = data.default?.translation.x || 0;
+            viewport.translation.y = data.default?.translation.y || 0;
+            logger.debug(
+              "updating cornerstone viewport with default translation values: ",
+              viewport.translation.x,
+              viewport.translation.y
+            );
+          }
+          if (renderOptions.rotation === undefined) {
+            viewport.rotation = data.default?.rotation;
+            logger.debug(
+              "updating cornerstone viewport with default rotation value: ",
+              viewport.rotation
+            );
+          }
+          // if the seriesUID has changed, update the viewport voi values
+          // with the default values from the series
+          // if the voi is not defined in the renderOptions
+          if (renderOptions.voi === undefined) {
+            viewport.voi.windowWidth =
+              data.default?.voi?.windowWidth || image.windowWidth;
+            viewport.voi.windowCenter =
+              data.default?.voi?.windowCenter || image.windowCenter;
+            logger.debug(
+              "updating cornerstone viewport with default voi values: ",
+              viewport.voi.windowWidth,
+              viewport.voi.windowCenter
+            );
+          }
+        }
+        cornerstone.setViewport(element, viewport);
+
+        // set the optional custom color map
+        if (renderOptions.colormap !== undefined) {
+          applyColorMap(renderOptions.colormap);
+          logger.debug("updating cornerstone viewport with custom colormap");
         }
 
-        const storedViewport = cornerstone.getViewport(element);
+        storeViewportData(image, element.id, viewport as Viewport, data);
 
-        if (!storedViewport) {
-          logger.error("storedViewport not found");
-          reject("storedViewport not found for element: " + elementId);
-          return;
+        if (isSeriesUIDChanged) {
+          logger.debug("seriesUID changed, creating stack");
+          csToolsCreateStack(element, series.imageIds, data.imageIndex);
         }
 
-        storeViewportData(image, element.id, storedViewport as Viewport, data);
         setStore(["ready", element.id, true]);
         const t1 = performance.now();
         logger.debug(`Call to renderImage took ${t1 - t0} milliseconds.`);
@@ -671,15 +728,6 @@ export const renderImage = function (
       resolve(true);
     }
   });
-
-  if (isSeriesUIDChanged) {
-    logger.debug("seriesUID changed, creating stack");
-    csToolsCreateStack(
-      element,
-      series.imageIds,
-      (data.imageIndex as number) - 1
-    );
-  }
   return renderPromise;
 };
 
@@ -1023,12 +1071,16 @@ export const storeViewportData = function (
   setStore([
     "defaultViewport",
     elementId,
-    viewport.scale || 0,
-    viewport.rotation || 0,
-    viewport.translation?.x || 0,
-    viewport.translation?.y || 0,
-    data.default?.voi?.windowWidth,
-    data.default?.voi?.windowCenter,
+    (data.default && data.default.scale) || viewport.scale || 0,
+    (data.default && data.default.rotation) || 0,
+    (data.default && data.default.translation?.x) || 0,
+    (data.default && data.default.translation?.y) || 0,
+    (data.default && data.default?.voi?.windowWidth) ||
+      viewport.voi?.windowWidth ||
+      255,
+    (data.default && data.default?.voi?.windowCenter) ||
+      viewport.voi?.windowCenter ||
+      128,
     viewport.invert === true
   ]);
   setStore(["scale", elementId, viewport.scale || 0]);
@@ -1043,8 +1095,8 @@ export const storeViewportData = function (
   setStore([
     "contrast",
     elementId,
-    viewport.voi?.windowWidth || 0,
-    viewport.voi?.windowCenter || 0
+    viewport.voi?.windowWidth || 255,
+    viewport.voi?.windowCenter || 128
   ]);
   setStore(["isColor", elementId, data.isColor]);
   setStore(["isMultiframe", elementId, data.isMultiframe]);
@@ -1055,6 +1107,10 @@ export const storeViewportData = function (
   setStore(["isPDF", elementId, false]);
   setStore(["waveform", elementId, data.waveform]);
   setStore(["dsa", elementId, data.dsa]);
+
+  logger.debug("---Viewport data stored---");
+  logger.debug(store.get(["viewports", elementId]));
+  logger.debug("--------------------------");
 
   const t1 = performance.now();
   logger.debug(`Call to storeViewportData took ${t1 - t0} milliseconds.`);
@@ -1263,13 +1319,13 @@ const getTemporalSeriesData = function (series: Series): StoreViewport {
  * Get series metadata from default props and series' metadata
  * @instance
  * @function getSeriesData
- * @param {Object} series - The parsed data series
- * @param {Object} defaultProps - Optional default properties
+ * @param {Series} series - The parsed data series
+ * @param {RenderProps} renderOptions - Optional default properties
  * @return {StoreViewport} data - A data dictionary with parsed tags' values
  */
 const getSeriesData = function (
   series: Series,
-  defaultProps: StoreViewportOptions
+  renderOptions: RenderProps
 ): StoreViewport {
   type RecursivePartial<T> = {
     [P in keyof T]?: RecursivePartial<T[P]>;
@@ -1283,8 +1339,8 @@ const getSeriesData = function (
     data.isMultiframe = true;
     data.numberOfSlices = series.imageIds.length;
     data.imageIndex =
-      defaultProps?.sliceNumber !== undefined && defaultProps?.sliceNumber >= 0
-        ? defaultProps.sliceNumber
+      renderOptions.imageIndex !== undefined && renderOptions.imageIndex >= 0
+        ? renderOptions.imageIndex
         : 0;
     data.imageId = series.imageIds[data.imageIndex];
     data.isTimeserie = false;
@@ -1292,12 +1348,11 @@ const getSeriesData = function (
   } else if (series.is4D) {
     data.isMultiframe = false;
     data.isTimeserie = true;
-    // check with real indices
     data.numberOfSlices = series.numberOfImages;
     data.numberOfTemporalPositions = series.numberOfTemporalPositions;
     data.imageIndex =
-      defaultProps?.sliceNumber !== undefined && defaultProps?.sliceNumber >= 0
-        ? defaultProps.sliceNumber
+      renderOptions.imageIndex !== undefined && renderOptions.imageIndex >= 0
+        ? renderOptions.imageIndex
         : 0;
     data.timeIndex = 0;
     data.imageId = series.imageIds[data.imageIndex];
@@ -1317,16 +1372,11 @@ const getSeriesData = function (
   } else {
     data.isMultiframe = false;
     data.isTimeserie = false;
-    const numberOfSlices =
-      defaultProps && defaultProps.numberOfSlices
-        ? defaultProps.numberOfSlices
-        : series.imageIds.length;
-    data.numberOfSlices = numberOfSlices;
+    data.numberOfSlices = series.imageIds.length;
     data.imageIndex =
-      defaultProps?.sliceNumber !== undefined && defaultProps?.sliceNumber >= 0 // slice number between 0 and n-1
-        ? defaultProps.sliceNumber
-        : Math.floor(numberOfSlices / 2);
-
+      renderOptions.imageIndex !== undefined && renderOptions.imageIndex >= 0 // slice number between 0 and n-1
+        ? renderOptions.imageIndex
+        : Math.floor(series.imageIds.length / 2);
     data.imageId = series.imageIds[data.imageIndex];
   }
   const instance: Instance | null = data.imageId
@@ -1346,31 +1396,50 @@ const getSeriesData = function (
     data.spacing_x = spacing ? spacing[0] : 1;
     data.spacing_y = spacing ? spacing[1] : 1;
 
+    // voi contrast value from metadata or renderOptions
+    const windowCenter =
+      renderOptions.voi !== undefined
+        ? renderOptions.voi.windowCenter
+        : (instance.metadata.x00281050 as number);
+    const windowWidth =
+      renderOptions.voi !== undefined
+        ? renderOptions.voi.windowWidth
+        : (instance.metadata.x00281051 as number);
+
     // window center and window width
     data.viewport = {
       voi: {
-        windowCenter:
-          defaultProps && defaultProps.wc
-            ? defaultProps.wc
-            : (instance.metadata.x00281050 as number),
-        windowWidth:
-          defaultProps && defaultProps.ww
-            ? defaultProps.ww
-            : (instance.metadata.x00281051 as number)
+        windowCenter: windowCenter,
+        windowWidth: windowWidth
       }
     };
-    data.default = {
-      voi: {
-        windowCenter:
-          defaultProps && has(defaultProps, "defaultWC")
-            ? defaultProps.defaultWC
-            : (instance.metadata.x00281050 as number),
-        windowWidth:
-          defaultProps && has(defaultProps, "defaultWW")
-            ? defaultProps.defaultWW
-            : (instance.metadata.x00281051 as number)
-      }
+    // store default values for the viewport voi from the series metadata
+    data.default = {};
+    data.default!.voi = {
+      windowCenter: instance.metadata.x00281050 as number,
+      windowWidth: instance.metadata.x00281051 as number
     };
+    data.default.rotation = 0;
+    data.default.translation = { x: 0, y: 0 };
+
+    if (renderOptions.default !== undefined) {
+      if (renderOptions.default.scale !== undefined) {
+        data.default!.scale = renderOptions.default.scale;
+      }
+      if (renderOptions.default.translation !== undefined) {
+        data.default!.translation!.x = renderOptions.default.translation.x;
+        data.default!.translation!.y = renderOptions.default.translation.y;
+      }
+      if (renderOptions.default.rotation !== undefined) {
+        data.default!.rotation = renderOptions.default.rotation;
+      }
+      if (renderOptions.default.voi !== undefined) {
+        data.default!.voi = {
+          windowCenter: renderOptions.default.voi.windowCenter,
+          windowWidth: renderOptions.default.voi.windowWidth
+        };
+      }
+    }
 
     if (
       (data.rows == null || data.cols == null) &&

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -38,7 +38,7 @@ import { setPixelShift } from "./loaders/dsaImageLoader";
  * disableViewport(elementId)
  * unloadViewport(elementId, seriesId)
  * resizeViewport(elementId)
- * renderImage(series, elementId, remderOptions)
+ * renderImage(series, elementId, renderOptions)
  * redrawImage(elementId)
  * resetViewports([elementIds])
  * updateViewportData(elementId)

--- a/imaging/imageTools.js
+++ b/imaging/imageTools.js
@@ -26,7 +26,6 @@ import { isElement } from "./imageUtils";
 
 /*
  * This module provides the following functions to be exported:
- * csToolsCreateStack(element)
  * addDefaultTools(toolToActivate)
  * clearMeasurements()
  * addContoursTool(rawContours, maskName)

--- a/imaging/postProcessing/applyDSA.ts
+++ b/imaging/postProcessing/applyDSA.ts
@@ -64,12 +64,16 @@ export const applyDSAShift = function (
   frameId: number,
   inputMaskSubPixelShift: number[]
 ): void {
+  if (multiFrameSerie.dsa === undefined) {
+    logger.error("DSA imageIds not already loaded");
+    return;
+  }
   const t0 = performance.now();
   // set in store the mask subpixel shift
   store.setDSAPixelShift(elementId, inputMaskSubPixelShift);
 
   // uncache image from cornestone cache
-  const imageId = multiFrameSerie.dsa!.imageIds[frameId];
+  const imageId = multiFrameSerie.dsa.imageIds[frameId];
   cornerstone.imageCache.removeImageLoadObject(imageId);
 
   // update image

--- a/imaging/postProcessing/applyDSA.ts
+++ b/imaging/postProcessing/applyDSA.ts
@@ -75,7 +75,7 @@ export const applyDSAShift = function (
   // update image
   renderImage(multiFrameSerie, elementId, {
     cached: true,
-    defaultProps: { sliceNumber: frameId }
+    imageIndex: frameId
   });
   redrawImage(elementId);
 

--- a/imaging/postProcessing/applyDSA.ts
+++ b/imaging/postProcessing/applyDSA.ts
@@ -74,8 +74,11 @@ export const applyDSAShift = function (
 
   // uncache image from cornestone cache
   const imageId = multiFrameSerie.dsa.imageIds[frameId];
-  cornerstone.imageCache.removeImageLoadObject(imageId);
-
+  try {
+    cornerstone.imageCache.removeImageLoadObject(imageId);
+  } catch (error) {
+    logger.error(`Error removing image from cache: ${error}`);
+  }
   // update image
   renderImage(multiFrameSerie, elementId, {
     cached: true,

--- a/imaging/tools/custom/gspsUtils/maskUtils.ts
+++ b/imaging/tools/custom/gspsUtils/maskUtils.ts
@@ -117,6 +117,6 @@ export function applyMask(serie: Series, element: HTMLElement): void {
   if (serie.isMultiframe) {
     const frameId = imageStore.get(["viewports", "viewer", "sliceId"]);
     imageStore.setDSAEnabled(element.id, true);
-    renderImage(serie, element.id, { defaultProps: { sliceNumber: frameId } });
+    renderImage(serie, element.id, { imageIndex: frameId });
   }
 }

--- a/imaging/tools/main.ts
+++ b/imaging/tools/main.ts
@@ -55,33 +55,25 @@ const initializeCSTools = function (
  * Create stack object to sync stack tools
  * @function csToolsCreateStack
  * @param {HTMLElement} element - The target html element.
- * @param {Array?} imageIds - Stack image ids.
+ * @param {Array} imageIds - Stack image ids.
  * @param {number?} currentImageIndex - The current image id.
  */
 const csToolsCreateStack = function (
   element: HTMLElement,
-  imageIds?: string[],
+  imageIds: string[],
   currentImageIndex?: number
 ) {
-  let stack;
-  if (imageIds) {
-    stack = {
-      currentImageIdIndex:
-        currentImageIndex === undefined ? 0 : currentImageIndex,
-      imageIds: imageIds
-    };
-  } else {
-    stack = {
-      currentImageIdIndex: 0,
-      imageIds: "imageLoader://0"
-    };
-    // check if there is an enabledElement with this id
-    // otherwise, we will get an error and we will enable it
-    try {
-      cornerstone.getEnabledElement(element);
-    } catch (e) {
-      cornerstone.enable(element);
-    }
+  const stack = {
+    currentImageIdIndex:
+      currentImageIndex === undefined ? 0 : currentImageIndex,
+    imageIds: imageIds
+  };
+  // check if there is an enabledElement with this id
+  // otherwise, we will get an error and we will enable it
+  try {
+    cornerstone.getEnabledElement(element);
+  } catch (e) {
+    cornerstone.enable(element);
   }
   cornerstoneTools.addStackStateManager(element, ["stack"]);
   cornerstoneTools.addToolState(element, "stack", stack);

--- a/imaging/types.d.ts
+++ b/imaging/types.d.ts
@@ -371,3 +371,22 @@ export type SingleFrameCache = {
   pixelData: TypedArray;
   metadata: MetaData;
 };
+
+type contrast = { windowCenter: number; windowWidth: number };
+type translation = { x: number; y: number };
+
+export type RenderProps = {
+  cached?: boolean;
+  imageIndex?: number;
+  scale?: number;
+  rotation?: number;
+  translation?: translation;
+  voi?: contrast;
+  colormap?: string;
+  default?: {
+    scale?: number;
+    rotation?: number;
+    translation?: translation;
+    voi?: contrast;
+  };
+};

--- a/imaging/waveforms/ecg.ts
+++ b/imaging/waveforms/ecg.ts
@@ -182,7 +182,7 @@ export const syncECGFrame = function (
         getDataFromImageManager(seriesId);
       if (series) {
         renderImage(series as Series, canvasId, {
-          defaultProps: { sliceNumber: frameId }
+          imageIndex: frameId
         });
         updateStackToolState(canvasId, frameId);
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
This PR introduces the `renderOptions` parameter in the `renderImage` function, replacing the previous `defaultProps` 
The new `RenderProps` type provides a more structured and flexible way to configure rendering settings, including:

- Caching behavior (cached)
- Image index (imageIndex)
- Viewport transformations: scale, rotation, translation
- Windowing and contrast settings (voi)
- Colormap selection (colormap)
- Default values for transformations and contrast adjustments

**Breaking Changes**
- The `defaultProps` parameter has been replaced by `renderOptions`.
- Existing calls to renderImage should be updated to pass a `RenderProps` object.