### PR TITLE
fix: convertColorSpace for multiframe RGBA images lossy jpeg

### DIFF
--- a/imaging/loaders/multiframeLoader.ts
+++ b/imaging/loaders/multiframeLoader.ts
@@ -374,12 +374,16 @@ let createCustomImage = function (
           throw new Error("Unable to get canvas context");
         }
 
-        let imageData = context.createImageData(
+        let imageData: ImageData = context.createImageData(
           imageFrame.columns,
           imageFrame.rows
         );
-
-        cornerstoneDICOMImageLoader.convertColorSpace(imageFrame, imageData);
+        // context.createImageData will always return an ImageData object with 4 components (RGBA)
+        cornerstoneDICOMImageLoader.convertColorSpace(
+          imageFrame, // input image frame
+          imageData.data, // data buffer to be filled
+          true // RGBA FLAG
+        );
 
         imageFrame.imageData = imageData;
         imageFrame.pixelData = imageData.data;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
This PR fixes an issue with mutliframe color images with no standard JPEG8BIT encoding.

Since` context.createImageData` creates always a RGBA array, we need to use the `rgba` boolean flag in the `convertColorSpace `function set to True.

Moreover, the colorBuffer to be passed to convertColorSpace is `imageData.data`

See: https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data


<img width="1157" alt="Screenshot 2025-03-26 192348" src="https://github.com/user-attachments/assets/9330b530-1f82-4d6f-99e6-a9f83b5f7a14" />

