### PR TITLE
FIX dsa: wwwl from srcImage

### DIFF
--- a/imaging/loaders/dsaImageLoader.ts
+++ b/imaging/loaders/dsaImageLoader.ts
@@ -140,16 +140,17 @@ let createCustomImage = function (
   let promise: Promise<Image> = new Promise((resolve, _) => {
     const minPixelValue = getMinPixelValue(pixelData);
     const maxPixelValue = getMaxPixelValue(pixelData);
-    const windowWidth = (maxPixelValue - minPixelValue) / 2;
-    const windowCenter = windowWidth / 2;
+
+    const computedWindowWidth = maxPixelValue - minPixelValue;
+    const computedWindowCenter = (maxPixelValue + minPixelValue) / 2;
     const image: Partial<Image> = {
       imageId: imageId,
       minPixelValue: minPixelValue,
       maxPixelValue: maxPixelValue,
       slope: srcImage.slope,
       intercept: srcImage.intercept,
-      windowCenter: windowCenter,
-      windowWidth: windowWidth,
+      windowCenter: srcImage.windowCenter || computedWindowCenter,
+      windowWidth: srcImage.windowWidth || computedWindowWidth,
       getPixelData: () => pixelData,
       rows: srcImage.rows,
       columns: srcImage.columns,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
This PR ensures that the window width (windowWidth) and window center (windowCenter) of images created with DSA-applied masks are correctly initialized by default to match those of the original image (srcImage).

**Key Changes & Behavior:**

- Default Values from Original Image:

If the original image (srcImage) has defined windowCenter and windowWidth, those values are used for the newly created image.

- Fallback Mechanism:

If windowCenter (middle of the computed range) or windowWidth (based on the pixel intensity range) are missing in the original image, fallback values are computed based on pixel intensity:
```
const computedWindowWidth = (maxPixelValue - minPixelValue) / 2;
const computedWindowCenter = (maxPixelValue + minPixelValue) / 2;
```