### PR TITLE
csToolsCreateStack called both in update and render Image

### DIFF
--- a/docs/api/rendering.md
+++ b/docs/api/rendering.md
@@ -147,10 +147,7 @@ All properties are optional.
    - Saves viewport settings to ensure consistency across different renderings.
    - Sets `ready` status in the store to `true`.
 
-8. **Cornerstone Tools Stack Synchronization**
-   - Synchronizes the stack of images in the viewport using `csToolsCreateStack`.
-
-9. **Performance Logging and Cleanup**
+8. **Performance Logging and Cleanup**
    - Logs the time taken for rendering.
    - Clears memory references to avoid memory leaks.
 
@@ -193,6 +190,46 @@ larvitar.renderImage(seriesStack, "viewer", options).then(() => {
 - This function is optimized to work with both single-frame and multi-frame DICOM images.
 - Uses `cornerstoneDICOMImageLoader` for fetching and handling image data.
 - Implements caching and efficient rendering techniques to improve performance.
+### Important Notes about csToolsCreateStack
+
+When rendering images (whether for initial rendering, rendering a new series, or re-rendering), you must manually call `csToolsCreateStack` to:
+
+1. Initialize the stackStateManager
+2. Add stack tool state to the cornerstoneTools environment
+3. Enable element interactions for tools
+
+This step is critical for synchronizing the stack of images in the viewports. The function should be called immediately after successful rendering to ensure stack state manager and stack tool state are properly configured.
+
+#### Function Signature
+
+```typescript
+export const csToolsCreateStack = function (
+  element: HTMLElement,
+  imageIds: string[],
+  currentImageIndex?: number
+)
+```
+
+#### Parameters
+
+| Parameter     | Type                    | Description                                                         |
+|---------------|-------------------------|---------------------------------------------------------------------|
+| `element` | `HTMLElement`                | The element where image stack is displayed.                             |
+| `imageIds`   | `string[]` | The IDs of the stack images. |
+| `currentImageIndex`     | `number`| the imageIndex of the currently displayed image      
+            |
+#### Example usage: 
+```typescript
+larvitar.renderImage(seriesStack, "viewer", options)
+  .then(() => {
+    // Initialize tools state manager and enable tools
+    csToolsCreateStack(elementId, seriesStack,imageIndexs);
+    console.log("Image successfully rendered with tools enabled.");
+  })
+  .catch((error) => {
+    console.error("Error rendering image:", error);
+  });
+```
 
 ## Rendering API `renderDICOMPDF`
 

--- a/docs/examples/4d.html
+++ b/docs/examples/4d.html
@@ -58,6 +58,7 @@ larvitar
     const serie = seriesStack[seriesId];
     larvitar.populateImageManager(seriesId, serie);
     larvitar.renderImage(serie, "viewer").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, frameId);
       larvitar.addDefaultTools();
       larvitar.setToolActive("CustomMouseWheelScroll");
     });
@@ -268,6 +269,12 @@ larvitar
           larvitar
             .renderImage(multiFrameSerie, "viewer", { imageIndex: frameId })
             .then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(
+                element,
+                multiFrameSerie.imageIds,
+                frameId
+              );
               larvitar.logger.debug("Image has been rendered");
               hideSpinner();
               frames_number = manager[seriesId].numberOfTemporalPositions;

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -127,6 +127,8 @@ larvitar
     const serie = seriesStack[seriesId];
     larvitar.populateImageManager(seriesId, serie);
     larvitar.renderImage(serie, "viewer").then(() => {
+          const element = document.getElementById("viewer");
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       larvitar.logger.debug("Image has been rendered");
       larvitar.addDefaultTools();
     });
@@ -560,6 +562,8 @@ larvitar
             // };
 
             larvitar.renderImage(serie, "viewer").then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               larvitar.logger.debug("Image has been rendered");
               hideSpinner(); // Hide the spinner when all files are processed
               larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
@@ -611,6 +615,8 @@ larvitar
           const newSeriesId = seriesIds[index - 1];
           const serie = stack[newSeriesId];
           larvitar.renderImage(serie, "viewer").then(() => {
+            const element = document.getElementById("viewer");
+            larvitar.csToolsCreateStack(element, serie.imageIds, 0);
             larvitar.logger.debug("Image has been rendered");
             larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
             hideSpinner(); // Hide the spinner when all files are processed
@@ -632,6 +638,8 @@ larvitar
           const newSeriesId = seriesIds[index + 1];
           const serie = stack[newSeriesId];
           larvitar.renderImage(serie, "viewer").then(() => {
+            const element = document.getElementById("viewer");
+            larvitar.csToolsCreateStack(element, serie.imageIds, 0);
             larvitar.logger.debug("Image has been rendered");
             larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
             hideSpinner(); // Hide the spinner when all files are processed

--- a/docs/examples/colorMaps.html
+++ b/docs/examples/colorMaps.html
@@ -78,6 +78,7 @@ larvitar
     let seriesId = Object.keys(seriesStack)[0];
     let serie = seriesStack[seriesId];
     larvitar.renderImage(serie, "viewer").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       larvitar.addDefaultTools();
       larvitar.setToolActive("Wwwc");
     });
@@ -242,6 +243,8 @@ larvitar
             let seriesId = Object.keys(seriesStack)[0];
             let serie = seriesStack[seriesId];
             larvitar.renderImage(serie, "viewer").then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               hideSpinner();
               larvitar.logger.debug("Image has been rendered");
               larvitar.addDefaultTools();

--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -58,6 +58,7 @@ larvitar
     let seriesId = Object.keys(seriesStack)[0];
     let serie = seriesStack[seriesId];
     larvitar.renderImage(serie, "viewer").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       larvitar.addDefaultTools();
 
       let mouseConfig = {
@@ -225,6 +226,8 @@ larvitar
             let seriesId = Object.keys(seriesStack)[0];
             let serie = seriesStack[seriesId];
             larvitar.renderImage(serie, "viewer").then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               hideSpinner();
               larvitar.logger.debug("Image has been rendered");
               larvitar.addDefaultTools();

--- a/docs/examples/dsa.html
+++ b/docs/examples/dsa.html
@@ -65,7 +65,7 @@ let multiFrameSerie = manager[seriesId];
 
 let frameId = 0;
 await larvitar.renderImage(multiFrameSerie, "viewer", { imageIndex: frameId });
-
+larvitar.csToolsCreateStack(element, serie.imageIds, frameId);
 larvitar.addDefaultTools();
 larvitar.setToolActive("Wwwc");
 await larvitar.loadAndCacheImageStack(multiFrameSerie);
@@ -215,6 +215,8 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
         await larvitar.renderImage(multiFrameSerie, "viewer", {
           imageIndex: frameId
         });
+        const element = document.getElementById("viewer");
+        larvitar.csToolsCreateStack(element, multiFrameSerie.imageIds, frameId);
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
 

--- a/docs/examples/ecg.html
+++ b/docs/examples/ecg.html
@@ -71,6 +71,7 @@ async function renderSerie() {
 
   // Render the first frame
   await larvitar.renderImage(multiFrameSerie, "viewer", { imageIndex: frameId });
+  larvitar.csToolsCreateStack(element, serie.imageIds, frameId);
   larvitar.addDefaultTools();
   larvitar.setToolActive("StackScroll");
 
@@ -267,6 +268,8 @@ async function renderSerie() {
         await larvitar.renderImage(multiFrameSerie, "viewer", {
           imageIndex: frameId
         });
+        const element = document.getElementById("viewer");
+        larvitar.csToolsCreateStack(element, serie.imageIds, frameId);
         hideSpinner();
         const t1 = performance.now();
         larvitar.logger.debug(
@@ -302,6 +305,8 @@ async function renderSerie() {
             cached: true,
             imageIndex: frameId
           });
+          const element = document.getElementById("viewer");
+          larvitar.csToolsCreateStack(element, series.imageIds, frameId);
           larvitar.updateStackToolState("viewer", frameId);
           document.getElementById("image-time").innerText =
             "Current Frame: " + parseInt(frameId + 1) + " of " + numberOfFrames;

--- a/docs/examples/external.html
+++ b/docs/examples/external.html
@@ -61,6 +61,7 @@ larvitar
     let seriesId = Object.keys(seriesStack)[0];
     let serie = seriesStack[seriesId];
     larvitar.renderImage(serie, "viewer").then(() => {
+        larvitar.csToolsCreateStack(element, serie.imageIds, 0);
     });
     // optionally cache the series
     larvitar.populateImageManager(seriesId, serie);
@@ -213,6 +214,8 @@ larvitar
             let seriesId = Object.keys(seriesStack)[0];
             let serie = seriesStack[seriesId];
             larvitar.renderImage(serie, "viewer").then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               hideSpinner();
               larvitar.logger.debug("Image has been rendered");
             });

--- a/docs/examples/gsps.html
+++ b/docs/examples/gsps.html
@@ -66,6 +66,7 @@ larvitar
     const serie = seriesStack[seriesId];
     larvitar.populateImageManager(seriesId, serie);
     larvitar.renderImage(serie, "viewer").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       larvitar.addDefaultTools();
       larvitar.setToolEnabled("Gsps")
     });
@@ -234,6 +235,8 @@ larvitar
             let manager = larvitar.getImageManager();
             let serie = manager[seriesId];
             larvitar.renderImage(serie, "viewer").then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               larvitar.logger.debug("Image has been rendered");
               hideSpinner(); // Hide the spinner when all files are processed
               larvitar.addDefaultTools();

--- a/docs/examples/layers.html
+++ b/docs/examples/layers.html
@@ -73,6 +73,7 @@ larvitar
     serie_2.layer = layer_2;
 
     larvitar.renderImage(serie_1, "viewer").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       larvitar.cacheImages(serie_1, function (resp) {
         if (resp.loading == 100) {
           let cache = larvitar.cornerstone.imageCache;
@@ -84,6 +85,7 @@ larvitar
         }
       });
       larvitar.renderImage(serie_2, "viewer").then(() => {
+        scsToolsCreateStack(element, serie.imageIds, 0);
         larvitar.cacheImages(serie_2, function (resp) {
           if (resp.loading == 100) {
             let cache = larvitar.cornerstone.imageCache;
@@ -257,6 +259,8 @@ larvitar
             serie_2.layer = layer_2;
 
             larvitar.renderImage(serie_1, "viewer").then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               hideSpinner();
               larvitar.logger.debug("Image 1 has been rendered");
               larvitar.cacheImages(serie_1, function (resp) {
@@ -270,6 +274,8 @@ larvitar
                 }
               });
               larvitar.renderImage(serie_2, "viewer").then(() => {
+                const element = document.getElementById("viewer");
+                larvitar.csToolsCreateStack(element, serie.imageIds, 0);
                 larvitar.logger.debug("Image 2 has been rendered");
                 larvitar.cacheImages(serie_2, function (resp) {
                   if (resp.loading == 100) {

--- a/docs/examples/masks.html
+++ b/docs/examples/masks.html
@@ -62,6 +62,7 @@ larvitar
     let seriesId = Object.keys(seriesStack)[0];
     let serie = seriesStack[seriesId];
     larvitar.renderImage(serie, "viewer").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       demoFiles = [];
       loadMasks();
       larvitar.addDefaultTools();
@@ -296,6 +297,8 @@ async function loadMasks() {
             let seriesId = Object.keys(seriesStack)[0];
             let serie = seriesStack[seriesId];
             larvitar.renderImage(serie, "viewer").then(() => {
+              const element = document.getElementById("viewer");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               larvitar.logger.debug("Image has been rendered");
               hideSpinner();
               demoFiles = [];

--- a/docs/examples/multiframe.html
+++ b/docs/examples/multiframe.html
@@ -64,6 +64,7 @@
 
   let frameId = 0;
   await larvitar.renderImage(multiFrameSerie, "viewer", {imageIndex: frameId});
+  larvitar.csToolsCreateStack(element, serie.imageIds, frameId); 
   const t1 = performance.now();
   larvitar.addDefaultTools();
   larvitar.setToolActive("StackScroll");
@@ -264,6 +265,8 @@
           cached: true,
           imageIndex: frameId
         });
+        const element = document.getElementById("viewer");
+        larvitar.csToolsCreateStack(element, multiFrameSerie.imageIds, frameId);
         hideSpinner();
         const t1 = performance.now();
         larvitar.logger.debug(

--- a/docs/examples/nrrd.html
+++ b/docs/examples/nrrd.html
@@ -59,6 +59,7 @@ reader.onload = function () {
   let volume = larvitar.importNRRDImage(reader.result);
   let serie = larvitar.buildNrrdImage(volume, "1234", {});
   larvitar.renderImage(serie, "viewer");
+  larvitar.csToolsCreateStack(element, serie.imageIds, 0);
   larvitar.addDefaultTools();
   larvitar.setToolActive("Wwwc");
 };
@@ -172,6 +173,8 @@ reader.onload = function () {
           let volume = larvitar.importNRRDImage(reader.result);
           let serie = larvitar.buildNrrdImage(volume, "1234", {});
           larvitar.renderImage(serie, "viewer");
+          const element = document.getElementById("viewer");
+          larvitar.csToolsCreateStack(element, serie.imageIds, 0);
           larvitar.logger.debug("Image has been rendered");
           hideSpinner();
           larvitar.addDefaultTools();

--- a/docs/examples/reslice.html
+++ b/docs/examples/reslice.html
@@ -91,12 +91,14 @@ larvitar
     let serie = seriesStack[seriesId];
     larvitar.populateImageManager(seriesId, serie);
     larvitar.renderImage(serie, "viewer-base").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       larvitar.logger.debug("Image axial has been rendered");
     });
     larvitar.cacheImages(serie, function (resp) {
       if (resp.loading == 100) {
         larvitar.resliceSeries(serie, "coronal").then(data => {
           larvitar.renderImage(data, "viewer-reslice").then(() => {
+            larvitar.csToolsCreateStack(element, serie.imageIds, 0);
             larvitar.logger.debug("Image resliced has been rendered");
           });
           larvitar.addDefaultTools();
@@ -243,6 +245,8 @@ larvitar
             let serie = seriesStack[seriesId];
             larvitar.populateImageManager(seriesId, serie);
             larvitar.renderImage(serie, "viewer-base").then(() => {
+              const element = document.getElementById("viewer-base");
+              larvitar.csToolsCreateStack(element, serie.imageIds, 0);
               hideSpinner(spinnerBase);
               larvitar.logger.debug("Image axial has been rendered");
             });
@@ -250,6 +254,8 @@ larvitar
               if (resp.loading == 100) {
                 larvitar.resliceSeries(serie, "coronal").then(data => {
                   larvitar.renderImage(data, "viewer-reslice").then(() => {
+                    const element = document.getElementById("viewer-reslice");
+                    larvitar.csToolsCreateStack(element, data.imageIds, 0);
                     hideSpinner(spinnerReslice);
                     larvitar.logger.debug("Image resliced has been rendered");
                   });

--- a/docs/examples/segmentationTools.html
+++ b/docs/examples/segmentationTools.html
@@ -94,6 +94,7 @@ const seriesStack = await larvitar.readFiles(demoFiles);
 let seriesId = Object.keys(seriesStack)[0];
 let serie = seriesStack[seriesId];
 await larvitar.renderImage(serie, "viewer");
+larvitar.csToolsCreateStack(element, serie.imageIds, 0);
 larvitar.addDefaultTools();
 loadMasks();
 
@@ -394,6 +395,8 @@ await larvitar
         let seriesId = Object.keys(seriesStack)[0];
         let serie = seriesStack[seriesId];
         await larvitar.renderImage(serie, "viewer");
+        const element = document.getElementById("viewer");
+        larvitar.csToolsCreateStack(element, serie.imageIds, 0);
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
         larvitar.addDefaultTools();

--- a/docs/examples/singleFrame.html
+++ b/docs/examples/singleFrame.html
@@ -268,6 +268,8 @@
             imageIndex: 0
           })
           .then(() => {
+            const element = document.getElementById(canvasId);
+            larvitar.csToolsCreateStack(element, dicomSerie.imageIds, 0);
             const t1 = performance.now();
             larvitar.logger.debug(
               "Call to renderImage took " + (t1 - t0) + " milliseconds."

--- a/docs/examples/watershedSegmentationTool.html
+++ b/docs/examples/watershedSegmentationTool.html
@@ -90,6 +90,7 @@ larvitar
     let seriesId = Object.keys(seriesStack)[0];
     let serie = seriesStack[seriesId];
     larvitar.renderImage(serie, "viewer").then(() => {
+      larvitar.csToolsCreateStack(element, serie.imageIds, 0);
       larvitar.logger.debug("Image has been rendered");
     });
     // optionally cache the series
@@ -398,6 +399,8 @@ larvitar
         let seriesId = Object.keys(seriesStack)[0];
         let serie = seriesStack[seriesId];
         await larvitar.renderImage(serie, "viewer");
+        const element = document.getElementById("viewer");
+        larvitar.csToolsCreateStack(element, serie.imageIds, 0);
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
         larvitar.addDefaultTools();

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -702,8 +702,6 @@ export const renderImage = function (
 
         storeViewportData(image, element.id, viewport as Viewport, data);
 
-        csToolsCreateStack(element, series.imageIds, data.imageIndex);
-
         setStore(["ready", element.id, true]);
         const t1 = performance.now();
         logger.debug(`Call to renderImage took ${t1 - t0} milliseconds.`);

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -702,10 +702,7 @@ export const renderImage = function (
 
         storeViewportData(image, element.id, viewport as Viewport, data);
 
-        if (isSeriesUIDChanged) {
-          logger.debug("seriesUID changed, creating stack");
-          csToolsCreateStack(element, series.imageIds, data.imageIndex);
-        }
+        csToolsCreateStack(element, series.imageIds, data.imageIndex);
 
         setStore(["ready", element.id, true]);
         const t1 = performance.now();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
This PR addresses an issue where renderImage is called in multiple situations, such as:

- When new images arrive (with the same seriesUID) -> update
- When the layout changes (also with the same seriesUID)

In the first case, calling csToolsCreateStack is unnecessary.
In the second case, it is actually correct to create the stack again.

To make this behavior more predictable and under control, this PR:

- Removes the internal call to csToolsCreateStack from renderImage
- Delegates the responsibility to the Larvitar user, who can manually decide when csToolsCreateStack should be invoked (e.g., only on layout changes or specific image updates)