### PR TITLE
feat: create and sync stack

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,4 +64,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: coverage-summary.md
-          body-includes: "## 🧪 TypeScript Coverage Summary"
+          body-includes: "## 🧪 TypeScript Coverage Report"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@
 
 🚀 Key Changes:
 
-- `csToolsCreateStack` and `csToolsSyncStack` now accept `elementId` as target html element or its string id.
+- `csToolsCreateStack` and `csToolsUpdateStack` now accept `elementId` as target html element or its string id.
 - `addDefaultTools` now accepts `elementId` as target html element or its string id and is no more optional.
 - `csToolsCreateStack` is no longer called during rendering process.
-- `disableViewport` now removes `seriesUID` from the stored viewport.
+- `disableViewport` now removes `uniqueUID` from the stored viewport.
+- `unloadViewport` now does not require anymore the `seriesUID` parameter.
+- `resetSeriesIds` in store has been renamed to `resetImageIds`.
+- `addSeriesId` in store has been renamed to `addImageIds`.
+- `removeSeriesId` in store has been renamed to `removeImageIds`.
 
 **New Feature:** `addDefaultTools` now includes `csToolsCreateStack` by default.
   
 **Deprecated Aliases for Backward Compatibility**:
-  - `csToolsUpdateImageIds → csToolsSyncStack`
+  - `csToolsUpdateImageIds → csToolsUpdateStack`
 
 
 ## [3.3.0] - 2025-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 🚀 Key Changes:
 
-- `csToolsCreateStack` and `csToolsUpdateStack` now accept `elementId` as target html element or its string id.
+- `csToolsCreateStack` has been replaced and included in `csToolsUpdateStack` for better clarity and consistency.
+- `csToolsUpdateStack` now accept `elementId` as target html element or its string id.
 - `addDefaultTools` now accepts `elementId` as target html element or its string id and is no more optional.
 - `csToolsCreateStack` is no longer called during rendering process.
 - `disableViewport` now removes `uniqueUID` from the stored viewport.
@@ -13,10 +14,12 @@
 - `addSeriesId` in store has been renamed to `addImageIds`.
 - `removeSeriesId` in store has been renamed to `removeImageIds`.
 
-**New Feature:** `addDefaultTools` now includes `csToolsCreateStack` by default.
+**New Feature:** `addDefaultTools` now includes `csToolsUpdateStack` by default.
   
 **Deprecated Aliases for Backward Compatibility**:
   - `csToolsUpdateImageIds → csToolsUpdateStack`
+  - `csToolsCreateStack → csToolsUpdateStack`
+  
 
 
 ## [3.3.0] - 2025-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.4.0] - 2025-04-15
+
+🚀 Key Changes:
+
+- `csToolsCreateStack` and `csToolsSyncStack` now accept `elementId` as target html element or its string id.
+- `addDefaultTools` now accepts `elementId` as target html element or its string id and is no more optional.
+- `csToolsCreateStack` is no longer called during rendering process.
+- `disableViewport` now removes `seriesUID` from the stored viewport.
+
+**New Feature:** `addDefaultTools` now includes `csToolsCreateStack` by default.
+  
+**Deprecated Aliases for Backward Compatibility**:
+  - `csToolsUpdateImageIds → csToolsSyncStack`
+
+
 ## [3.3.0] - 2025-03-21
 
 🚀 Key Changes:

--- a/docs/api/interacting.md
+++ b/docs/api/interacting.md
@@ -38,6 +38,15 @@ Interaction tools enhance the user's ability to navigate and manipulate medical 
 
 These tools ensure users can efficiently explore the image and focus on specific details.
 
+### Stack Tools
+In order to work with image stacks, Larvitar provides stack tool state functionality to populate and sync the imageids of a stack. This is useful for applications that require the manipulation of multiple images, such as:
+- **Image Series:** Viewing multiple slices of a 3D volume.
+- **Time Series:** Analyzing changes in images over time.
+- **Multi-modality Imaging:** Combining images from different modalities (e.g., CT, MRI) for comprehensive analysis.
+- **Multi-frame Images:** Handling images with multiple frames, such as ultrasound or video data.
+
+See [Stack Tools Creation and Synchronization](./modules/tools/initialization.html#stack-tools-creation-and-synchronization) for more details.
+
 ### Custom Tools
 
 Larvitar allows developers to create custom tools tailored to their specific imaging workflows. These tools can be:

--- a/docs/api/modules/managers/imageManager.md
+++ b/docs/api/modules/managers/imageManager.md
@@ -57,7 +57,7 @@ updateImageManager(
 | Parameter	      | Type	              | Description                                         | 
 |-----------------|---------------------|-----------------------------------------------------|
 | `imageObject`	  | ImageObject	        | A single DICOM object containing metadata and data. | 
-| `customId`	    | string	(Optional)  | Custom ID to overwrite the default seriesUID.       | 
+| `customId`	    | string	(Optional)  | Custom ID to overwrite the default uniqueUID.       | 
 | `sliceIndex`	  | number	(Optional)  | Index to overwrite default slice ordering.          |    
 
 #### Returns: 

--- a/docs/api/modules/store.md
+++ b/docs/api/modules/store.md
@@ -41,7 +41,7 @@ The store is defined by the [Store type](https://github.com/dvisionlab/Larvitar/
 | `errorLog	`       | `string`	                                | Error log for debugging.                                  |
 | `leftActiveTool`  | `string (optional)`	                    | Active tool for the left mouse button.                    |
 | `rightActiveTool` | `string (optional)`	                    | Active tool for the right mouse button.                   |
-| `series`	        | `{ [seriesUID: string]: StoreSeries }`    | Object mapping `seriesUID` to series-specific data.       |
+| `series`	        | `{ [uniqueUID: string]: StoreSeries }`    | Object mapping `uniqueUID` to series-specific data.       |
 | `viewports`	    | `{ [key: string]: StoreViewport }`	    | Object mapping viewport IDs to viewport-specific data.    |
 
 The `StoreSeries` type includes the following key properties:
@@ -57,7 +57,7 @@ The `StoreViewport` [type](https://github.com/dvisionlab/Larvitar/blob/master/im
 |-------------------------------|--------------- |---------------------------------------------------------------------------|
 | `loading` 	                 | `number`	    | Caching progress of the series from 0% to 100 %, initialized to null.     |
 | `ready`                       | `boolean`	    | True when the viewport is ready and imageId has been rendered.            |
-| `seriesUID`                   | `string?`	    | Unique identifier for the series.                                         |
+| `uniqueUID`                   | `string?`	    | Unique identifier for the series.                                         |
 | `modality`                    | `string`	    | Modality of the image (e.g., "CT").                                       |
 | `isColor`                     | `boolean`	    | True if the image is in color.                                            |
 | `isMultiframe`                | `boolean`	    | True if the image is multiframe.                                          |
@@ -139,25 +139,25 @@ store.deleteViewport(elementId);
 
 The store tracks series data, including image identifiers, caching status, and loading progress. 
 
-To add a series to the store, use the `addSeriesId` function with the series UID and imageIds:
+To add a set of imageIds to the store, use the `addImageIds` function with the uniqueUID and imageIds:
 
 ```typescript
 import { store } from 'larvitar';
-store.addSeriesId(seriesUID, imageIds);
+store.addImageIds(uniqueUID, imageIds);
 ```
 
-To remove a series from the store, use the `removeSeriesId` function with the series UID:
+To remove set of imageIds from the store, use the `removeImageIds` function with the uniqueUID:
 
 ```typescript
 import { store } from 'larvitar';
-store.removeSeriesId(seriesUID);
+store.removeImageIds(uniqueUID);
 ```
 
-To remove all series from the store, use the `resetSeriesIds` function:
+To remove all imageIds from the store, use the `resetImageIds` function:
 
 ```typescript
 import { store } from 'larvitar';
-store.resetSeriesIds();
+store.resetImageIds();
 ```
 
 ### Useful functions

--- a/docs/api/modules/tools/default.md
+++ b/docs/api/modules/tools/default.md
@@ -51,7 +51,7 @@ Zoom: {
 ```typescript
 store.addViewport("viewer");
 initializeCSTools();
-addDefaultTools();
+addDefaultTools("viewer");
 setToolActive("Wwwc"); //explicitly set the active tool. If not, default active is StackScroll
 ```
 
@@ -162,7 +162,7 @@ addDefaultTools(elementId: string): void
 
 | Parameter  | Type   | Description                                                                    |
 | ---------- | ------ | ------------------------------------------------------------------------------ |
-| `toolName` | string | The id of the cornerstone Enabled Element on which the tools will be activated |
+| `elementId` | string | The id of the cornerstone Enabled Element on which the tools will be activated |
 
 #### Returns
 

--- a/docs/api/modules/tools/initialization.md
+++ b/docs/api/modules/tools/initialization.md
@@ -29,11 +29,11 @@ The stack tools creation and synchronization process involves creating a stack o
 
 You can create a stack object using the `csToolsCreateStack` function, which takes the target HTML element, image IDs, and the current image index as parameters. This function initializes the stack object and prepares it for synchronization.
 
-You can then use the `csToolsSyncStack` function to update the stack object with new image IDs, ensuring that all tools are synchronized with the current image stack. This is particularly useful when working with multiple images or stacks, as it allows for seamless interaction and manipulation of the images.
+You can then use the `csToolsUpdateStack` function to update the stack object with new image IDs, ensuring that all tools are synchronized with the current image stack. This is particularly useful when working with multiple images or stacks, as it allows for seamless interaction and manipulation of the images.
 
-If you use the `addDefaultTools` function, the stack tools are automatically created. This means that you don't need to manually call `csToolsCreateStack` or `csToolsSyncStack` unless you want to customize the stack behavior.
+If you use the `addDefaultTools` function, the stack tools are automatically created. This means that you don't need to manually call `csToolsCreateStack` or `csToolsUpdateStack` unless you want to customize the stack behavior.
 
-When you create the stack tool if you do not have all imageIds available, you can use the `csToolsSyncStack` function to update the stack object with new image IDs. This allows you to add or remove images from the stack dynamically, ensuring that all tools remain synchronized with the current image stack.
+When you create the stack tool if you do not have all imageIds available, you can use the `csToolsUpdateStack` function to update the stack object with new image IDs. This allows you to add or remove images from the stack dynamically, ensuring that all tools remain synchronized with the current image stack.
 
 
 ### Key Concepts: Tool States
@@ -103,22 +103,23 @@ csToolsCreateStack (
 
 `void`
 
-### `csToolsSyncStack`
+### `csToolsUpdateStack`
 
 Update stack object to sync stack tools
 
 #### Syntax
 
 ```typescript
-csToolsSyncStack(elementId: string, imageIds: string[])
+csToolsUpdateStack(elementId: string, { imageIds?: string[], currentImageIndex?: number })
 ```
 
 #### Parameters
 
-| Parameter   | Type     | Description                 |
-| ----------- | -------- | --------------------------- |
-| `elementId` | string   | The target html element id. |
-| `imageIds`  | string[] | Stack image ids.            |
+| Parameter            | Type     | Description                 |
+| -------------------- | -------- | --------------------------- |
+| `elementId`          | string   | The target html element id. |
+| `imageIds`           | string[] | Stack image ids.            |
+| `currentImageIndex`  | string[] | Current image id index      |
 
 #### Returns
 

--- a/docs/api/modules/tools/initialization.md
+++ b/docs/api/modules/tools/initialization.md
@@ -27,13 +27,11 @@ setToolActive("WatershedSegmentation"); // Activates the "WatershedSegmentation"
 ## Stack Tools Creation and Synchronization
 The stack tools creation and synchronization process involves creating a stack object and updating it to ensure that all tools are synchronized with the current image stack.
 
-You can create a stack object using the `csToolsCreateStack` function, which takes the target HTML element, image IDs, and the current image index as parameters. This function initializes the stack object and prepares it for synchronization.
+You can create or update a stack object using the `csToolsUpdateStack` function, which takes the target HTML element, image IDs, and the current image index as parameters. This function initializes and updates the stack object and prepares it for synchronization.
 
-You can then use the `csToolsUpdateStack` function to update the stack object with new image IDs, ensuring that all tools are synchronized with the current image stack. This is particularly useful when working with multiple images or stacks, as it allows for seamless interaction and manipulation of the images.
+If you use the `addDefaultTools` function, the stack tools are automatically created. This means that you need to manually call `csToolsUpdateStack` only if you want to customize the stack behavior.
 
-If you use the `addDefaultTools` function, the stack tools are automatically created. This means that you don't need to manually call `csToolsCreateStack` or `csToolsUpdateStack` unless you want to customize the stack behavior.
-
-When you create the stack tool if you do not have all imageIds available, you can use the `csToolsUpdateStack` function to update the stack object with new image IDs. This allows you to add or remove images from the stack dynamically, ensuring that all tools remain synchronized with the current image stack.
+You can use the `csToolsUpdateStack` function to update the stack object with new image IDs. This allows you to add or remove images from the stack dynamically, ensuring that all tools remain synchronized with the current image stack.
 
 
 ### Key Concepts: Tool States
@@ -77,35 +75,10 @@ initializeCSTools({ showSVGCursors: false }, { color: "0000FF" });
 
 `void`
 
-### `csToolsCreateStack`
-
-Create stack object to sync stack tools
-
-#### Syntax
-
-```typescript
-csToolsCreateStack (
-  element: HTMLElement,
-  imageIds?: string[],
-  currentImageIndex?: number
-)
-```
-
-#### Parameters
-
-| Parameter           | Type        | Description              |
-| ------------------- | ----------- | ------------------------ |
-| `element`           | HTMLElement | The target html element. |
-| `imageIds`          | string[]    | Stack image ids.         |
-| `currentImageIndex` | number      | The current image id.    |
-
-#### Returns
-
-`void`
 
 ### `csToolsUpdateStack`
 
-Update stack object to sync stack tools
+Create or update stack object to sync stack tools
 
 #### Syntax
 
@@ -115,11 +88,17 @@ csToolsUpdateStack(elementId: string, { imageIds?: string[], currentImageIndex?:
 
 #### Parameters
 
-| Parameter            | Type     | Description                 |
-| -------------------- | -------- | --------------------------- |
-| `elementId`          | string   | The target html element id. |
-| `imageIds`           | string[] | Stack image ids.            |
-| `currentImageIndex`  | string[] | Current image id index      |
+| Parameter            | Type      | Description                 |
+| -------------------- | --------- | --------------------------- |
+| `elementId`          | string    | The target html element id. |
+| `stack`              | StackType | Stack definition            |
+
+#### StackType Definition
+
+| Parameter            | Type     | Description                       |
+| -------------------- | -------- | --------------------------------- |
+| `imageIds`           | string[] | Stack image ids, optional         |
+| `currentImageIndex`  | number   | Current image id index, optional  |
 
 #### Returns
 

--- a/docs/api/modules/tools/initialization.md
+++ b/docs/api/modules/tools/initialization.md
@@ -20,9 +20,21 @@ Alternatively, developers can load default tools (see [Default and Custom Tools]
 store.initialize();
 addViewport("viewer");
 initializeCSTools(); // Prepares the default Cornerstone tools environment.
-addDefaultTools(); // Adds the default tools, which can also include custom-defined tools.
+addDefaultTools("viewer"); // Adds the default tools, which can also include custom-defined tools.
 setToolActive("WatershedSegmentation"); // Activates the "WatershedSegmentation" custom tool for user interaction.
 ```
+
+## Stack Tools Creation and Synchronization
+The stack tools creation and synchronization process involves creating a stack object and updating it to ensure that all tools are synchronized with the current image stack.
+
+You can create a stack object using the `csToolsCreateStack` function, which takes the target HTML element, image IDs, and the current image index as parameters. This function initializes the stack object and prepares it for synchronization.
+
+You can then use the `csToolsSyncStack` function to update the stack object with new image IDs, ensuring that all tools are synchronized with the current image stack. This is particularly useful when working with multiple images or stacks, as it allows for seamless interaction and manipulation of the images.
+
+If you use the `addDefaultTools` function, the stack tools are automatically created. This means that you don't need to manually call `csToolsCreateStack` or `csToolsSyncStack` unless you want to customize the stack behavior.
+
+When you create the stack tool if you do not have all imageIds available, you can use the `csToolsSyncStack` function to update the stack object with new image IDs. This allows you to add or remove images from the stack dynamically, ensuring that all tools remain synchronized with the current image stack.
+
 
 ### Key Concepts: Tool States
 
@@ -91,14 +103,14 @@ csToolsCreateStack (
 
 `void`
 
-### `csToolsUpdateImageIds`
+### `csToolsSyncStack`
 
 Update stack object to sync stack tools
 
 #### Syntax
 
 ```typescript
-csToolsUpdateImageIds(elementId: string, imageIds: string[])
+csToolsSyncStack(elementId: string, imageIds: string[])
 ```
 
 #### Parameters

--- a/docs/api/rendering.md
+++ b/docs/api/rendering.md
@@ -147,10 +147,7 @@ All properties are optional.
    - Saves viewport settings to ensure consistency across different renderings.
    - Sets `ready` status in the store to `true`.
 
-8. **Cornerstone Tools Stack Synchronization**
-   - Synchronizes the stack of images in the viewport using `csToolsCreateStack`.
-
-9. **Performance Logging and Cleanup**
+8. **Performance Logging and Cleanup**
    - Logs the time taken for rendering.
    - Clears memory references to avoid memory leaks.
 

--- a/docs/examples/4d.html
+++ b/docs/examples/4d.html
@@ -58,7 +58,7 @@ larvitar
     const serie = seriesStack[seriesId];
     larvitar.populateImageManager(seriesId, serie);
     larvitar.renderImage(serie, "viewer").then(() => {
-      larvitar.addDefaultTools();
+      larvitar.addDefaultTools("viewer");
       larvitar.setToolActive("CustomMouseWheelScroll");
     });
   })`;
@@ -271,7 +271,7 @@ larvitar
               larvitar.logger.debug("Image has been rendered");
               hideSpinner();
               frames_number = manager[seriesId].numberOfTemporalPositions;
-              larvitar.addDefaultTools();
+              larvitar.addDefaultTools("viewer");
               larvitar.setToolActive("CustomMouseWheelScroll");
               // add information on UI regarding timeId, timestamp and sliceId
               changeStamps();

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -123,9 +123,9 @@ larvitar.store.addViewport("viewer");
 larvitar
   .readFiles(fileList)
   .then(seriesStack => {
-    const seriesId = Object.keys(seriesStack)[0];
-    const serie = seriesStack[seriesId];
-    larvitar.populateImageManager(seriesId, serie);
+    const uniqueUID = Object.keys(seriesStack)[0];
+    const serie = seriesStack[uniqueUID];
+    larvitar.populateImageManager(uniqueUID, serie);
     larvitar.renderImage(serie, "viewer").then(() => {
       larvitar.logger.debug("Image has been rendered");
       larvitar.addDefaultTools("viewer");
@@ -511,17 +511,17 @@ larvitar
         const modal = document.getElementById("metadataModal");
         const tableBody = document.querySelector("#metadataTable tbody");
         const stack = larvitar.getImageManager();
-        const seriesId = larvitar.store.get([
+        const uniqueUID = larvitar.store.get([
           "viewports",
           "viewer",
-          "seriesUID"
+          "uniqueUID"
         ]);
         const sliceId = larvitar.store.get(["viewports", "viewer", "sliceId"]);
-        const imageId = stack[seriesId].imageIds[sliceId];
+        const imageId = stack[uniqueUID].imageIds[sliceId];
         const instanceUid =
-          stack[seriesId].instances[imageId].metadata.instanceUID;
+          stack[uniqueUID].instances[imageId].metadata.instanceUID;
         const metadata = larvitar.getImageMetadata(
-          seriesId,
+          uniqueUID,
           instanceUid,
           sliceId
         );
@@ -541,9 +541,9 @@ larvitar
               larvitar.populateImageManager(uniqueId, data);
             }
             // render the first series of the study
-            let seriesId = Object.keys(seriesStack)[0];
+            let uniqueUID = Object.keys(seriesStack)[0];
             let manager = larvitar.getImageManager();
-            let serie = manager[seriesId];
+            let serie = manager[uniqueUID];
 
             // const options = {
             //   imageIndex: 3,
@@ -598,16 +598,16 @@ larvitar
       function previousImage() {
         const stack = larvitar.getImageManager();
         const seriesIds = Object.keys(stack);
-        const seriesId = larvitar.store.get([
+        const uniqueUID = larvitar.store.get([
           "viewports",
           "viewer",
-          "seriesUID"
+          "uniqueUID"
         ]);
-        const index = seriesIds.indexOf(seriesId);
+        const index = seriesIds.indexOf(uniqueUID);
         if (index > 0) {
           showSpinner();
-          const newSeriesId = seriesIds[index - 1];
-          const serie = stack[newSeriesId];
+          const newUniqueUID = seriesIds[index - 1];
+          const serie = stack[newUniqueUID];
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
             larvitar.addDefaultTools("viewer");
@@ -619,16 +619,16 @@ larvitar
       function nextImage() {
         const stack = larvitar.getImageManager();
         const seriesIds = Object.keys(stack);
-        const seriesId = larvitar.store.get([
+        const uniqueUID = larvitar.store.get([
           "viewports",
           "viewer",
-          "seriesUID"
+          "uniqueUID"
         ]);
-        const index = seriesIds.indexOf(seriesId);
+        const index = seriesIds.indexOf(uniqueUID);
         if (index < seriesIds.length - 1) {
           showSpinner();
-          const newSeriesId = seriesIds[index + 1];
-          const serie = stack[newSeriesId];
+          const newUniqueUID = seriesIds[index + 1];
+          const serie = stack[newUniqueUID];
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
             larvitar.addDefaultTools("viewer");

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -128,7 +128,7 @@ larvitar
     larvitar.populateImageManager(seriesId, serie);
     larvitar.renderImage(serie, "viewer").then(() => {
       larvitar.logger.debug("Image has been rendered");
-      larvitar.addDefaultTools();
+      larvitar.addDefaultTools("viewer");
     });
   })`;
 
@@ -562,9 +562,7 @@ larvitar
             larvitar.renderImage(serie, "viewer").then(() => {
               larvitar.logger.debug("Image has been rendered");
               hideSpinner(); // Hide the spinner when all files are processed
-              larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
-              larvitar.addDefaultTools();
-              larvitar.setToolActive("Wwwc");
+              larvitar.addDefaultTools("viewer");
             });
 
             series = serie;
@@ -612,7 +610,7 @@ larvitar
           const serie = stack[newSeriesId];
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
-            larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
+            larvitar.addDefaultTools("viewer");
             hideSpinner(); // Hide the spinner when all files are processed
           });
         }
@@ -633,7 +631,7 @@ larvitar
           const serie = stack[newSeriesId];
           larvitar.renderImage(serie, "viewer").then(() => {
             larvitar.logger.debug("Image has been rendered");
-            larvitar.csToolsUpdateImageIds("viewer", serie.imageIds);
+            larvitar.addDefaultTools("viewer");
             hideSpinner(); // Hide the spinner when all files are processed
           });
         }

--- a/docs/examples/colorMaps.html
+++ b/docs/examples/colorMaps.html
@@ -78,7 +78,7 @@ larvitar
     let seriesId = Object.keys(seriesStack)[0];
     let serie = seriesStack[seriesId];
     larvitar.renderImage(serie, "viewer").then(() => {
-      larvitar.addDefaultTools();
+      larvitar.addDefaultTools("viewer");
       larvitar.setToolActive("Wwwc");
     });
   })
@@ -244,7 +244,7 @@ larvitar
             larvitar.renderImage(serie, "viewer").then(() => {
               hideSpinner();
               larvitar.logger.debug("Image has been rendered");
-              larvitar.addDefaultTools();
+              larvitar.addDefaultTools("viewer");
               larvitar.setToolActive("Wwwc");
             });
           })

--- a/docs/examples/defaultTools.html
+++ b/docs/examples/defaultTools.html
@@ -58,7 +58,7 @@ larvitar
     let seriesId = Object.keys(seriesStack)[0];
     let serie = seriesStack[seriesId];
     larvitar.renderImage(serie, "viewer").then(() => {
-      larvitar.addDefaultTools();
+      larvitar.addDefaultTools("viewer");
 
       let mouseConfig = {
         keyboard_shortcuts: {
@@ -227,7 +227,7 @@ larvitar
             larvitar.renderImage(serie, "viewer").then(() => {
               hideSpinner();
               larvitar.logger.debug("Image has been rendered");
-              larvitar.addDefaultTools();
+              larvitar.addDefaultTools("viewer");
 
               let mouseConfig = {
                 keyboard_shortcuts: {

--- a/docs/examples/dsa.html
+++ b/docs/examples/dsa.html
@@ -66,7 +66,7 @@ let multiFrameSerie = manager[seriesId];
 let frameId = 0;
 await larvitar.renderImage(multiFrameSerie, "viewer", { imageIndex: frameId });
 
-larvitar.addDefaultTools();
+larvitar.addDefaultTools("viewer");
 larvitar.setToolActive("Wwwc");
 await larvitar.loadAndCacheImageStack(multiFrameSerie);
 await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
@@ -218,7 +218,7 @@ await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
 
-        larvitar.addDefaultTools();
+        larvitar.addDefaultTools("viewer");
         larvitar.setToolActive("Wwwc");
         await larvitar.loadAndCacheImageStack(multiFrameSerie);
         await larvitar.loadAndCacheDsaImageStack(multiFrameSerie);

--- a/docs/examples/ecg.html
+++ b/docs/examples/ecg.html
@@ -71,7 +71,7 @@ async function renderSerie() {
 
   // Render the first frame
   await larvitar.renderImage(multiFrameSerie, "viewer", { imageIndex: frameId });
-  larvitar.addDefaultTools();
+  larvitar.addDefaultTools("viewer");
   larvitar.setToolActive("StackScroll");
 
   let updateECG = true;
@@ -272,7 +272,7 @@ async function renderSerie() {
         larvitar.logger.debug(
           "Time to render First frame: " + (t1 - t0) + "ms"
         );
-        larvitar.addDefaultTools();
+        larvitar.addDefaultTools("viewer");
         larvitar.setToolActive("StackScroll");
 
         let updateECG = true;

--- a/docs/examples/external.html
+++ b/docs/examples/external.html
@@ -215,6 +215,9 @@ larvitar
             larvitar.renderImage(serie, "viewer").then(() => {
               hideSpinner();
               larvitar.logger.debug("Image has been rendered");
+              larvitar.addDefaultTools("viewer");
+              larvitar.addTool("Test");
+              larvitar.setToolActive("Test");
             });
             // optionally cache the series
             larvitar.populateImageManager(seriesId, serie);
@@ -228,8 +231,6 @@ larvitar
                 );
               }
             });
-            larvitar.addTool("Test");
-            larvitar.setToolActive("Test");
           })
           .catch(err => larvitar.logger.error(err));
       }

--- a/docs/examples/gsps.html
+++ b/docs/examples/gsps.html
@@ -66,7 +66,7 @@ larvitar
     const serie = seriesStack[seriesId];
     larvitar.populateImageManager(seriesId, serie);
     larvitar.renderImage(serie, "viewer").then(() => {
-      larvitar.addDefaultTools();
+      larvitar.addDefaultTools("viewer");
       larvitar.setToolEnabled("Gsps")
     });
   })
@@ -236,7 +236,7 @@ larvitar
             larvitar.renderImage(serie, "viewer").then(() => {
               larvitar.logger.debug("Image has been rendered");
               hideSpinner(); // Hide the spinner when all files are processed
-              larvitar.addDefaultTools();
+              larvitar.addDefaultTools("viewer");
               larvitar.setToolEnabled("Gsps");
               larvitar.setToolActive("Wwwc");
             });

--- a/docs/examples/layers.html
+++ b/docs/examples/layers.html
@@ -94,7 +94,7 @@ larvitar
             );
           }
         });
-        larvitar.addDefaultTools();
+        larvitar.addDefaultTools("viewer");
       });
     });
   })
@@ -281,7 +281,7 @@ larvitar
                     );
                   }
                 });
-                larvitar.addDefaultTools();
+                larvitar.addDefaultTools("viewer");
               });
             });
 

--- a/docs/examples/masks.html
+++ b/docs/examples/masks.html
@@ -64,7 +64,7 @@ larvitar
     larvitar.renderImage(serie, "viewer").then(() => {
       demoFiles = [];
       loadMasks();
-      larvitar.addDefaultTools();
+      larvitar.addDefaultTools("viewer");
     });
   })
 
@@ -300,7 +300,7 @@ async function loadMasks() {
               hideSpinner();
               demoFiles = [];
               loadMasks();
-              larvitar.addDefaultTools();
+              larvitar.addDefaultTools("viewer");
             });
           })
           .catch(err => larvitar.logger.error(err));

--- a/docs/examples/multiframe.html
+++ b/docs/examples/multiframe.html
@@ -65,7 +65,7 @@
   let frameId = 0;
   await larvitar.renderImage(multiFrameSerie, "viewer", {imageIndex: frameId});
   const t1 = performance.now();
-  larvitar.addDefaultTools();
+  larvitar.addDefaultTools("viewer");
   larvitar.setToolActive("StackScroll");
 
   // Optionally cache images
@@ -269,7 +269,7 @@
         larvitar.logger.debug(
           "Time to render First frame: " + (t1 - t0) + "ms"
         );
-        larvitar.addDefaultTools();
+        larvitar.addDefaultTools("viewer");
         larvitar.setToolActive("StackScroll");
 
         // optionally cache images

--- a/docs/examples/nrrd.html
+++ b/docs/examples/nrrd.html
@@ -59,7 +59,7 @@ reader.onload = function () {
   let volume = larvitar.importNRRDImage(reader.result);
   let serie = larvitar.buildNrrdImage(volume, "1234", {});
   larvitar.renderImage(serie, "viewer");
-  larvitar.addDefaultTools();
+  larvitar.addDefaultTools("viewer");
   larvitar.setToolActive("Wwwc");
 };
 `;
@@ -174,7 +174,7 @@ reader.onload = function () {
           larvitar.renderImage(serie, "viewer");
           larvitar.logger.debug("Image has been rendered");
           hideSpinner();
-          larvitar.addDefaultTools();
+          larvitar.addDefaultTools("viewer");
           larvitar.setToolActive("Wwwc");
         };
       });

--- a/docs/examples/nrrd.html
+++ b/docs/examples/nrrd.html
@@ -171,11 +171,12 @@ reader.onload = function () {
         reader.onload = function () {
           let volume = larvitar.importNRRDImage(reader.result);
           let serie = larvitar.buildNrrdImage(volume, "1234", {});
-          larvitar.renderImage(serie, "viewer");
-          larvitar.logger.debug("Image has been rendered");
-          hideSpinner();
-          larvitar.addDefaultTools("viewer");
-          larvitar.setToolActive("Wwwc");
+          larvitar.renderImage(serie, "viewer").then(() => {
+            larvitar.logger.debug("Image has been rendered");
+            hideSpinner();
+            larvitar.addDefaultTools("viewer");
+            larvitar.setToolActive("Wwwc");
+          });
         };
       });
 

--- a/docs/examples/pdf.html
+++ b/docs/examples/pdf.html
@@ -67,7 +67,7 @@ larvitar
     let serie =
       manager["1.2.276.0.7230010.3.1.3.296485376.1.1664404001.305752"];
     larvitar.renderDICOMPDF(serie, "viewer", true).then(() => {
-      larvitar.addDefaultTools();
+      larvitar.addDefaultTools("viewer");
       larvitar.setToolActive("Pan"); //sx pan dx zoom
     });
   })`;
@@ -183,7 +183,7 @@ larvitar
             larvitar.renderDICOMPDF(serie, "viewer", true).then(() => {
               larvitar.logger.debug("PDF has been rendered");
               hideSpinner();
-              larvitar.addDefaultTools();
+              larvitar.addDefaultTools("viewer");
               larvitar.setToolActive("Pan"); //sx pan dx zoom
             });
           })

--- a/docs/examples/reslice.html
+++ b/docs/examples/reslice.html
@@ -99,7 +99,7 @@ larvitar
           larvitar.renderImage(data, "viewer-reslice").then(() => {
             larvitar.logger.debug("Image resliced has been rendered");
           });
-          larvitar.addDefaultTools();
+          larvitar.addDefaultTools("viewer");
           larvitar.setToolActive("Wwwc");
         });
       }
@@ -245,6 +245,8 @@ larvitar
             larvitar.renderImage(serie, "viewer-base").then(() => {
               hideSpinner(spinnerBase);
               larvitar.logger.debug("Image axial has been rendered");
+              larvitar.addDefaultTools("viewer-base");
+              larvitar.setToolActive("Wwwc");
             });
             larvitar.cacheImages(serie, function (resp) {
               if (resp.loading == 100) {
@@ -252,9 +254,9 @@ larvitar
                   larvitar.renderImage(data, "viewer-reslice").then(() => {
                     hideSpinner(spinnerReslice);
                     larvitar.logger.debug("Image resliced has been rendered");
+                    larvitar.addDefaultTools("viewer-reslice");
+                    larvitar.setToolActive("Wwwc");
                   });
-                  larvitar.addDefaultTools();
-                  larvitar.setToolActive("Wwwc");
                 });
               }
             });

--- a/docs/examples/segmentationTools.html
+++ b/docs/examples/segmentationTools.html
@@ -94,7 +94,7 @@ const seriesStack = await larvitar.readFiles(demoFiles);
 let seriesId = Object.keys(seriesStack)[0];
 let serie = seriesStack[seriesId];
 await larvitar.renderImage(serie, "viewer");
-larvitar.addDefaultTools();
+larvitar.addDefaultTools("viewer");
 loadMasks();
 
 // optionally cache the series
@@ -396,7 +396,7 @@ await larvitar
         await larvitar.renderImage(serie, "viewer");
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
-        larvitar.addDefaultTools();
+        larvitar.addDefaultTools("viewer");
         loadMasks();
 
         // optionally cache the series

--- a/docs/examples/singleFrame.html
+++ b/docs/examples/singleFrame.html
@@ -276,7 +276,7 @@
 
             // cine LOOP
             if (frameId === 0) {
-              larvitar.addDefaultTools();
+              larvitar.addDefaultTools("viewer");
               larvitar.setToolActive("StackScroll");
               frameId++;
               const frameRate =

--- a/docs/examples/watershedSegmentationTool.html
+++ b/docs/examples/watershedSegmentationTool.html
@@ -109,7 +109,7 @@ larvitar
       .then(() => {
         setTimeout(function () {
           larvitar.logger.debug("Cache has been loaded. Calling loadMasks.");
-          larvitar.addDefaultTools();
+          larvitar.addDefaultTools("viewer");
           loadMasks();
         }, 3000);
       });
@@ -400,7 +400,7 @@ larvitar
         await larvitar.renderImage(serie, "viewer");
         hideSpinner();
         larvitar.logger.debug("Image has been rendered");
-        larvitar.addDefaultTools();
+        larvitar.addDefaultTools("viewer");
         await loadMasks();
       }
 

--- a/imaging/imageIo.ts
+++ b/imaging/imageIo.ts
@@ -156,7 +156,7 @@ export const buildData = function (series: Series, useSeriesData: boolean) {
       logger.info(`Call to buildData took ${t1 - t0} milliseconds.`);
       return data;
     } else {
-      store.addSeriesId(series.seriesUID, series.imageIds);
+      store.addImageIds(series.uniqueUID, series.imageIds);
       let image_counter = 0;
       forEach(series.imageIds, function (imageId: string) {
         getCachedPixelData(imageId).then((sliceData: number[]) => {
@@ -217,7 +217,7 @@ export const buildDataAsync = function (
     let offsetData = 0;
 
     let imageIds = getSortedStack(series as Series, ["imagePosition"], true);
-    store.addSeriesId(series.seriesUID, series.imageIds);
+    store.addImageIds(series.uniqueUID, series.imageIds);
 
     function runFillPixelData(data: TypedArray) {
       let imageId = imageIds.shift();

--- a/imaging/imageLoading.ts
+++ b/imaging/imageLoading.ts
@@ -173,7 +173,7 @@ export const registerDsaImageLoader = function () {
  * @function updateLoadedStack
  * @param {Object} seriesData - Cornerstone series object
  * @param {Object} allSeriesStack - Dict containing all series objects
- * @param {String} customId - Optional custom id to overwrite seriesUID as default one
+ * @param {String} customId - Optional custom id to overwrite uniqueUID as default one
  * @param {number} sliceIndex - Optional custom index to overwrite slice index as default one
  */
 export const updateLoadedStack = function (
@@ -296,7 +296,7 @@ export const updateLoadedStack = function (
       allSeriesStack[id].instanceUIDs[iid] = imageId;
     }
 
-    store.addSeriesId(id, allSeriesStack[id].imageIds);
+    store.addImageIds(id, allSeriesStack[id].imageIds);
   } else if (isNewInstance(allSeriesStack[id].instances, iid!)) {
     // generate an imageId for the file and store it
     // in allSeriesStack imageIds array, used by
@@ -340,10 +340,10 @@ export const updateLoadedStack = function (
       } else {
         allSeriesStack[id].instanceUIDs[iid] = imageId;
       }
-      store.addSeriesId(id, allSeriesStack[id].imageIds);
+      store.addImageIds(id, allSeriesStack[id].imageIds);
     } else {
       allSeriesStack[id].instanceUIDs[iid] = imageId;
-      store.addSeriesId(id, allSeriesStack[id].imageIds);
+      store.addImageIds(id, allSeriesStack[id].imageIds);
     }
   }
 };

--- a/imaging/imageManagers.ts
+++ b/imaging/imageManagers.ts
@@ -74,7 +74,7 @@ export const populateImageManager = function (
  * @instance
  * @function updateImageManager
  * @param {Object} imageObject The single dicom object
- * @param {String} customId - Optional custom id to overwrite seriesUID as default one
+ * @param {String} customId - Optional custom id to overwrite uniqueUID as default one
  * @param {number} sliceIndex - Optional custom index to overwrite slice index as default one
  */
 export const updateImageManager = function (
@@ -87,12 +87,12 @@ export const updateImageManager = function (
   }
   let data = { ...imageObject };
   if (data.metadata?.isMultiframe && data.file && data.dataSet) {
-    let seriesId = customId || imageObject.metadata.seriesUID;
+    let uniqueUID = customId || imageObject.metadata.uniqueUID;
     let loadedStack: ReturnType<typeof getImageManager> = {};
     updateLoadedStack(data, loadedStack, customId, sliceIndex);
     buildMultiFrameImage(
-      seriesId as string,
-      loadedStack[seriesId as string] as Series
+      uniqueUID as string,
+      loadedStack[uniqueUID as string] as Series
     );
   } else {
     updateLoadedStack(data, imageManager, customId, sliceIndex);
@@ -128,7 +128,7 @@ export const resetImageManager = function () {
       }
       (stack as Series).dataSet = null;
       (stack as Series).elements = null;
-      clearMultiFrameCache(stack.seriesUID);
+      clearMultiFrameCache(stack.uniqueUID);
     }
     each(stack.instances, function (instance) {
       if (instance.dataSet) {

--- a/imaging/imageReslice.ts
+++ b/imaging/imageReslice.ts
@@ -66,14 +66,14 @@ export function resliceSeries(
         ) as Uint16Array;
         imageTracker[imageId] = reslicedSeriesId;
       });
-      store.addSeriesId(reslicedSeriesId, reslicedSeries.imageIds);
+      store.addImageIds(reslicedSeriesId, reslicedSeries.imageIds);
       reslicedSeries.numberOfImages = reslicedSeries.imageIds.length;
       reslicedSeries.seriesUID = reslicedSeriesId;
       reslicedSeries.seriesDescription = seriesData.seriesDescription;
       reslicedSeries.orientation = orientation;
       manager[reslicedSeriesId] = reslicedSeries;
       //@ts-ignore deprecated
-      manager[seriesData.seriesUID][orientation] = reslicedSeriesId;
+      manager[seriesData.uniqueUID][orientation] = reslicedSeriesId;
       let t1 = performance.now();
       logger.info(`Call to resliceSeries took ${t1 - t0} milliseconds.`);
       resolve(reslicedSeries);

--- a/imaging/imageStore.ts
+++ b/imaging/imageStore.ts
@@ -21,7 +21,7 @@ type Store = {
   errorLog: string;
   leftActiveTool?: string;
   rightActiveTool?: string;
-  series: { [seriesUID: string]: StoreSeries };
+  series: { [uniqueUID: string]: StoreSeries };
   viewports: { [key: string]: StoreViewport };
   // fallback for any other field
   [key: string]: any;
@@ -66,7 +66,7 @@ type SetPayload =
     ]
   | ["cached", string, string, boolean]
   | ["timestamp", string, number | undefined]
-  | ["seriesUID" | "modality", string, string | undefined]
+  | ["uniqueUID" | "modality", string, string | undefined]
   | ["pendingSliceId", string, number | undefined]
   | ["timestamps" | "timeIds" | "pixelShift", string, number[]]
   | [
@@ -93,7 +93,7 @@ let STORE: Store;
 // Data listeners
 let storeListener: ((data: Store) => {}) | undefined = undefined;
 const seriesListeners = {} as {
-  [seriesId: string]: (data: StoreSeries) => {};
+  [uniqueUID: string]: (data: StoreSeries) => {};
 };
 const viewportsListeners = {} as {
   [elementId: string]: (data: StoreViewport) => {};
@@ -181,9 +181,9 @@ const triggerViewportListener = (elementId: string) => {
   }
 };
 
-const triggerSeriesListener = (seriesId: string) => {
-  if (seriesListeners[seriesId] && STORE?.series[seriesId]) {
-    seriesListeners[seriesId](STORE.series[seriesId]);
+const triggerSeriesListener = (uniqueUID: string) => {
+  if (seriesListeners[uniqueUID] && STORE?.series[uniqueUID]) {
+    seriesListeners[uniqueUID](STORE.series[uniqueUID]);
   }
 };
 
@@ -218,7 +218,7 @@ const setValue = (store: Store, data: SetPayload) => {
       triggerSeriesListener(k);
       break;
 
-    case "seriesUID":
+    case "uniqueUID":
       if (!viewport) {
         return;
       }
@@ -426,24 +426,24 @@ export default {
     delete STORE!.viewports[name];
   },
   // add/remove series instances ids
-  addSeriesId: (seriesId: string, imageIds: string[]) => {
+  addImageIds: (uniqueUID: string, imageIds: string[]) => {
     validateStore();
-    if (!STORE!.series[seriesId]) {
-      STORE!.series[seriesId] = {} as StoreSeries;
+    if (!STORE!.series[uniqueUID]) {
+      STORE!.series[uniqueUID] = {} as StoreSeries;
     }
-    STORE!.series[seriesId].imageIds = imageIds;
+    STORE!.series[uniqueUID].imageIds = imageIds;
     // for each imageId create a cached[imageId] = false
-    STORE!.series[seriesId].cached = {};
+    STORE!.series[uniqueUID].cached = {};
     imageIds.forEach(imageId => {
-      STORE!.series[seriesId].cached[imageId] = false;
+      STORE!.series[uniqueUID].cached[imageId] = false;
     });
-    triggerSeriesListener(seriesId);
+    triggerSeriesListener(uniqueUID);
   },
-  removeSeriesId: (seriesId: string) => {
+  removeImageIds: (uniqueUID: string) => {
     validateStore();
-    delete STORE!.series[seriesId];
+    delete STORE!.series[uniqueUID];
   },
-  resetSeriesIds: () => {
+  resetImageIds: () => {
     validateStore();
     STORE!.series = {};
   },
@@ -491,12 +491,12 @@ export default {
   },
   // watch single series
   addSeriesListener: (
-    seriesId: string,
+    uniqueUID: string,
     listener: (data: StoreSeries) => {}
   ) => {
-    seriesListeners[seriesId] = listener;
+    seriesListeners[uniqueUID] = listener;
   },
-  removeSeriesListener: (seriesId: string) => {
-    delete seriesListeners[seriesId];
+  removeSeriesListener: (uniqueUID: string) => {
+    delete seriesListeners[uniqueUID];
   }
 };

--- a/imaging/imageUtils.ts
+++ b/imaging/imageUtils.ts
@@ -63,7 +63,7 @@ const resliceTable: {
  * getReslicedPixeldata(imageId, originalData, reslicedData)
  * getDistanceBetweenSlices(seriesData, sliceIndex1, sliceIndex2)
  * isElement(o)
- * getImageMetadata(seriesUID, instanceUID)
+ * getImageMetadata(uniqueUID, instanceUID)
  */
 
 /**
@@ -404,6 +404,7 @@ export const getReslicedMetadata = function (
     });
 
     // set human readable metadata.
+    metadata.uniqueUID = reslicedSeriesId;
     metadata.seriesUID = reslicedSeriesId;
     metadata.rows = metadata.x00280010;
     metadata.cols = metadata.x00280011;
@@ -642,19 +643,19 @@ export const getDistanceBetweenSlices = function (
 /**
  * @instance
  * @function getImageMetadata
- * @param {String} seriesId - The seriesUID
+ * @param {String} uniqueUID - The unique UID of the series
  * @param {String} instanceUID - The SOPInstanceUID
  * @param {number} frameId - Optional FrameId
  * @return {Array} - List of metadata objects: tag, name and value
  */
 export const getImageMetadata = function (
-  seriesId: string,
+  uniqueUID: string,
   instanceUID: string,
   frameId?: number
 ) {
-  const seriesData = getDataFromImageManager(seriesId);
+  const seriesData = getDataFromImageManager(uniqueUID);
   if (seriesData === undefined || seriesData === null) {
-    logger.warn(`Invalid Series ID: ${seriesId}`);
+    logger.warn(`Invalid Series ID: ${uniqueUID}`);
     return [];
   }
 

--- a/imaging/loaders/dicomLoader.ts
+++ b/imaging/loaders/dicomLoader.ts
@@ -71,12 +71,12 @@ export const loadAndCacheImageStack = async function (
 ): Promise<void> {
   return new Promise(async (resolve, _) => {
     const t0 = performance.now();
-    store.addSeriesId(seriesData.seriesUID, seriesData.imageIds);
+    store.addImageIds(seriesData.uniqueUID, seriesData.imageIds);
     let imageIds = seriesData.imageIds;
     // add DSA imageIds to store
     if (seriesData.dsa !== undefined) {
-      const dsaSeriesUID = seriesData.seriesUID + "-DSA";
-      store.addSeriesId(dsaSeriesUID, seriesData.dsa.imageIds);
+      const dsaUniqueUID = seriesData.uniqueUID + "-DSA";
+      store.addImageIds(dsaUniqueUID, seriesData.dsa.imageIds);
     }
     // load and cache image stack
 

--- a/imaging/loaders/multiframeLoader.ts
+++ b/imaging/loaders/multiframeLoader.ts
@@ -31,7 +31,7 @@ let multiframeDatasetCache: { [key: string]: Series | null } | null = null;
 /*
  * This module provides the following functions to be exported:
  * loadMultiFrameImage(elementId)
- * buildMultiFrameImage(seriesId, serie)
+ * buildMultiFrameImage(uniqueUID, serie)
  * getMultiFrameImageId(customLoaderName)
  * clearMultiFrameCache()
  */
@@ -50,7 +50,7 @@ export const loadMultiFrameImage: ImageLoader = function (
 
   let rootImageId = parsedImageId.scheme + ":" + parsedImageId.url;
   let imageTracker = getImageTracker();
-  let seriesId = imageTracker[rootImageId];
+  let uniqueUID = imageTracker[rootImageId];
   let manager = getImageManager() as ImageManager;
   if (multiframeDatasetCache === null) {
     multiframeDatasetCache = {};
@@ -59,9 +59,9 @@ export const loadMultiFrameImage: ImageLoader = function (
   if (multiframeDatasetCache[rootImageId]) {
     multiframeDatasetCache[rootImageId] = multiframeDatasetCache[rootImageId];
   } else if (manager) {
-    multiframeDatasetCache[rootImageId] = manager[seriesId] as Series;
+    multiframeDatasetCache[rootImageId] = manager[uniqueUID] as Series;
   } else {
-    throw new Error("No multiframe dataset found for seriesId: " + seriesId);
+    throw new Error("No multiframe dataset found for uniqueUID: " + uniqueUID);
   }
 
   let metadata =
@@ -73,7 +73,7 @@ export const loadMultiFrameImage: ImageLoader = function (
  * Build the multiframe layout in the Image Manager
  * @export
  * @function buildMultiFrameImage
- * @param {String} seriesId - SeriesId tag
+ * @param {String} uniqueUID - the uniqueUID of the series
  * @param {Object} serie - parsed serie object
  */
 export const buildMultiFrameImage = function (
@@ -92,7 +92,7 @@ export const buildMultiFrameImage = function (
   let imageId = getMultiFrameImageId("multiFrameLoader");
   imageTracker[imageId] = uniqueUID;
 
-  // check if manager exists for this seriesId
+  // check if manager exists for this uniqueUID
   if (!manager[uniqueUID]) {
     manager[uniqueUID] = serie;
     manager[uniqueUID].imageIds = [];
@@ -143,7 +143,7 @@ export const buildMultiFrameImage = function (
     populateDsaImageIds(uniqueUID);
   }
 
-  store.addSeriesId(uniqueUID, serie.imageIds);
+  store.addImageIds(uniqueUID, serie.imageIds);
 
   let t1 = performance.now();
   logger.debug(`Call to buildMultiFrameImage took ${t1 - t0} milliseconds.`);
@@ -166,15 +166,15 @@ export const getMultiFrameImageId = function (customLoaderName: string) {
  * Clear the multiframe cache
  * @instance
  * @function clearMultiFrameCache
- * @param {String} seriesId - SeriesId tag
+ * @param {String} uniqueUID - the uniqueUID of the series
  */
-export const clearMultiFrameCache = function (seriesId: string) {
+export const clearMultiFrameCache = function (uniqueUID: string) {
   let t0 = performance.now();
   each(multiframeDatasetCache, function (image, imageId) {
     if (!image) {
       return;
     }
-    if (seriesId == image.seriesUID || !seriesId) {
+    if (uniqueUID == image.uniqueUID || !uniqueUID) {
       if (image.dataSet) {
         // @ts-ignore: modify external type ?
         image.dataSet.byteArray = null;
@@ -191,7 +191,7 @@ export const clearMultiFrameCache = function (seriesId: string) {
       delete multiframeDatasetCache![imageId];
     }
   });
-  if (!seriesId) {
+  if (!uniqueUID) {
     multiframeDatasetCache = null;
   }
   let t1 = performance.now();

--- a/imaging/loaders/nrrdLoader.ts
+++ b/imaging/loaders/nrrdLoader.ts
@@ -19,6 +19,7 @@ import {
 
 import { getImageFrame } from "./commonLoader";
 import { getImageTracker, getImageManager } from "../imageManagers";
+import store from "../imageStore";
 
 import type {
   Image,
@@ -74,6 +75,7 @@ export const buildNrrdImage = function (
   image.numberOfImages = 0;
   image.seriesDescription = "";
   image.seriesUID = seriesId;
+  image.uniqueUID = seriesId;
 
   let header: Partial<NrrdHeader> = {};
   header.volume = {} as Volume;
@@ -273,13 +275,14 @@ export const getNrrdImageId = function (customLoaderName: string) {
  * @return {Object} custom image object
  */
 export const loadNrrdImage: ImageLoader = function (imageId: string) {
-  let manager = getImageManager() as ImageManager;
-  let imageTracker = getImageTracker() as ImageTracker;
+  const manager = getImageManager() as ImageManager;
+  const imageTracker = getImageTracker() as ImageTracker;
   if (!manager || !imageTracker) {
     throw new Error("Image manager or image tracker not initialized");
   }
-  let seriesId = imageTracker[imageId];
-  let instance = manager[seriesId].instances[imageId];
+  const uniqueUID = imageTracker[imageId];
+  const instance = manager[uniqueUID].instances[imageId];
+  store.addImageIds(uniqueUID, manager[uniqueUID].imageIds);
   //@ts-ignore TODO-ts: fix this why is different typed array?
   return createCustomImage(imageId, instance.metadata, instance.pixelData);
 };

--- a/imaging/monitors/memory.ts
+++ b/imaging/monitors/memory.ts
@@ -30,8 +30,8 @@ var customMemoryLimit: number | null = null;
  * Check memory allocation and clear memory if needed
  * @instance
  * @function checkAndClearMemory
- * @param {Number} - Number of bytes to allocate
- * @param {Array} - Rendered Series ids
+ * @param {Number} bytes - Number of bytes to allocate
+ * @param {Array} renderedSeriesIds - Rendered Series ids
  */
 export const checkAndClearMemory = function (
   bytes: number,
@@ -41,16 +41,16 @@ export const checkAndClearMemory = function (
   if (isEnough === false) {
     const manager = getImageManager();
     // get all key of manager and create a list
-    const seriesIds = Object.keys(manager);
+    const uniqueUIDs = Object.keys(manager);
     // create a list of non rendered series ids
-    const nonRenderedSeriesIds = seriesIds.filter(
-      seriesId => !renderedSeriesIds.includes(seriesId)
+    const nonRenderedUniqueIds = uniqueUIDs.filter(
+      uniqueUID => !renderedSeriesIds.includes(uniqueUID)
     );
     // remove non rendered series from manager
-    nonRenderedSeriesIds.forEach(seriesId => {
-      removeDataFromImageManager(seriesId);
-      clearImageCache(seriesId);
-      store.removeSeriesId(seriesId);
+    nonRenderedUniqueIds.forEach(uniqueUID => {
+      removeDataFromImageManager(uniqueUID);
+      clearImageCache(uniqueUID);
+      store.removeImageIds(uniqueUID);
     });
   }
 };
@@ -59,7 +59,7 @@ export const checkAndClearMemory = function (
  * Check memory allocation and returns false if js Heap size has reached its limit
  * @instance
  * @function checkMemoryAllocation
- * @param {Number} - Number of bytes to allocate
+ * @param {Number} bytes - Number of bytes to allocate
  * @return {Boolean} - Returns a boolean flag to warn the user about memory allocation limit
  */
 export const checkMemoryAllocation = function (bytes: number) {
@@ -89,7 +89,7 @@ export const checkMemoryAllocation = function (bytes: number) {
  * @function getUsedMemory
  * @return {Number} - Returns used JSHeapSize in bytes or NaN if not supported
  */
-export const getUsedMemory = function () {
+export const getUsedMemory = function (): number {
   return checkMemorySupport()
     ? (performance as Performance).memory.usedJSHeapSize
     : NaN;
@@ -101,7 +101,7 @@ export const getUsedMemory = function () {
  * @function getAvailableMemory
  * @return {Number} - Returns available JSHeapSize in bytes or NaN if not supported
  */
-export const getAvailableMemory = function () {
+export const getAvailableMemory = function (): number {
   if (checkMemorySupport()) {
     return customMemoryLimit
       ? customMemoryLimit
@@ -115,7 +115,7 @@ export const getAvailableMemory = function () {
  * Check performance.memory browser support and returns available Js Heap Size in Mb
  * @instance
  * @function setAvailableMemory
- * @param {Number} - Number of GB to set as maximum custom memory limit
+ * @param {Number} value - Number of GB to set as maximum custom memory limit
  */
 export const setAvailableMemory = function (value: number) {
   customMemoryLimit = value * 1024 * 1024 * 1024;
@@ -131,7 +131,7 @@ export const setAvailableMemory = function (value: number) {
  * @function checkMemorySupport
  * @return {Boolean} - Returns memory object or false if not supported
  */
-const checkMemorySupport = function () {
+const checkMemorySupport = function (): boolean {
   return (performance as Performance).memory
     ? (performance as Performance).memory
     : false;
@@ -144,6 +144,6 @@ const checkMemorySupport = function () {
  * @param {Number} bytes - Memory in bytes
  * @return {Number} - Memory in MB
  */
-const getMB = function (bytes: number) {
+const getMB = function (bytes: number): number {
   return bytes / 1048576;
 };

--- a/imaging/tools/custom/gspsTool.ts
+++ b/imaging/tools/custom/gspsTool.ts
@@ -84,12 +84,12 @@ export default class GspsTool extends BaseTool {
       const viewport = cornerstone.getViewport(element) as Viewport;
       this.originalViewport = structuredClone(viewport);
 
-      const { manager, seriesId } = this.retrieveLarvitarManager(
+      const { manager, uniqueUID } = this.retrieveLarvitarManager(
         image!.imageId
       );
 
       if (manager) {
-        const serie = manager[seriesId];
+        const serie = manager[uniqueUID];
         const currentInstanceUID =
           serie.instances[image!.imageId].metadata.instanceUID!;
         let gspsManager: GSPSManager = getGSPSManager();
@@ -162,10 +162,10 @@ export default class GspsTool extends BaseTool {
     const canvas = eventData.canvasContext.canvas;
     const context = getNewContext(eventData.canvasContext.canvas);
     const viewport = cornerstone.getViewport(element) as Viewport;
-    const { manager, seriesId } = this.retrieveLarvitarManager(image.imageId);
+    const { manager, uniqueUID } = this.retrieveLarvitarManager(image.imageId);
     let instanceUID: string | null = null;
     if (manager) {
-      const serie = manager[seriesId];
+      const serie = manager[uniqueUID];
       instanceUID = serie.instances[image.imageId].metadata
         .instanceUID! as string;
     }
@@ -313,7 +313,7 @@ export default class GspsTool extends BaseTool {
   }
 
   /*
-   Retrieves the Larvitar manager and associated seriesUID for a given imageId,
+   Retrieves the Larvitar manager and associated uniqueUID for a given imageId,
    facilitating DICOM-compliant image tracking and management.
 */
   retrieveLarvitarManager(imageId: string) {
@@ -322,8 +322,8 @@ export default class GspsTool extends BaseTool {
 
     const rootImageId = parsedImageId.scheme + ":" + parsedImageId.url;
     const imageTracker = getImageTracker();
-    const seriesId: string = imageTracker[rootImageId];
+    const uniqueUID: string = imageTracker[rootImageId];
     const manager = getImageManager() as ImageManager;
-    return { manager, seriesId };
+    return { manager, uniqueUID };
   }
 }

--- a/imaging/tools/default.ts
+++ b/imaging/tools/default.ts
@@ -100,7 +100,7 @@ const DEFAULT_TOOLS: {
     cleanable: false,
     defaultActive: true,
     class: "WwwcTool",
-    // sync: "wwwcSynchronizer",
+    sync: "wwwcSynchronizer",
     description: "Change image contrast",
     shortcut: "ctrl-m",
     type: "utils"
@@ -116,7 +116,7 @@ const DEFAULT_TOOLS: {
     cleanable: false,
     defaultActive: false,
     class: "WwwcRegionTool",
-    // sync: "wwwcSynchronizer",
+    sync: "wwwcSynchronizer",
     description: "Change image contrast based on selected region",
     shortcut: "ctrl-m",
     type: "utils"
@@ -130,7 +130,7 @@ const DEFAULT_TOOLS: {
     },
     cleanable: false,
     defaultActive: false,
-    // sync: "wwwcSynchronizer",
+    sync: "wwwcSynchronizer",
     type: "utils",
     name: "WwwcRemoveRegion",
     class: "WwwcRemoveRegionTool",

--- a/imaging/types.d.ts
+++ b/imaging/types.d.ts
@@ -38,7 +38,7 @@ export type StoreViewport = {
   maxSliceId: number;
   sliceId: number;
   pendingSliceId?: number;
-  seriesUID?: string;
+  uniqueUID?: string;
   minTimeId: number;
   maxTimeId: number;
   timeId: number;
@@ -336,6 +336,7 @@ export type NrrdSeries = {
   numberOfImages: number;
   seriesDescription: string;
   seriesUID: string;
+  uniqueUID: string;
   customLoader: string;
   nrrdHeader: NrrdHeader;
   bytes: number;

--- a/index.ts
+++ b/index.ts
@@ -179,7 +179,7 @@ import {
 
 import {
   csToolsCreateStack,
-  csToolsSyncStack,
+  csToolsUpdateStack,
   initializeCSTools,
   setToolsStyle,
   addDefaultTools,
@@ -470,7 +470,7 @@ export {
   setSegmentationConfig,
   // tools/main
   csToolsCreateStack,
-  csToolsSyncStack,
+  csToolsUpdateStack,
   initializeCSTools,
   setToolsStyle,
   addDefaultTools,
@@ -593,7 +593,7 @@ export const updateImage = createAliasWithWarning(
 );
 
 export const csToolsUpdateImageIds = createAliasWithWarning(
-  csToolsSyncStack,
-  "csToolsSyncStack",
+  csToolsUpdateStack,
+  "csToolsUpdateStack",
   "csToolsUpdateImageIds"
 );

--- a/index.ts
+++ b/index.ts
@@ -178,7 +178,6 @@ import {
 } from "./imaging/imageTools";
 
 import {
-  csToolsCreateStack,
   csToolsUpdateStack,
   initializeCSTools,
   setToolsStyle,
@@ -469,7 +468,6 @@ export {
   updateStackToolState,
   setSegmentationConfig,
   // tools/main
-  csToolsCreateStack,
   csToolsUpdateStack,
   initializeCSTools,
   setToolsStyle,
@@ -596,4 +594,10 @@ export const csToolsUpdateImageIds = createAliasWithWarning(
   csToolsUpdateStack,
   "csToolsUpdateStack",
   "csToolsUpdateImageIds"
+);
+
+export const csToolsCreateStack = createAliasWithWarning(
+  csToolsUpdateStack,
+  "csToolsUpdateStack",
+  "csToolsCreateStack"
 );

--- a/index.ts
+++ b/index.ts
@@ -179,7 +179,7 @@ import {
 
 import {
   csToolsCreateStack,
-  csToolsUpdateImageIds,
+  csToolsSyncStack,
   initializeCSTools,
   setToolsStyle,
   addDefaultTools,
@@ -470,7 +470,7 @@ export {
   setSegmentationConfig,
   // tools/main
   csToolsCreateStack,
-  csToolsUpdateImageIds,
+  csToolsSyncStack,
   initializeCSTools,
   setToolsStyle,
   addDefaultTools,
@@ -590,4 +590,10 @@ export const updateImage = createAliasWithWarning(
   "renderImage",
   "updateImage",
   true
+);
+
+export const csToolsUpdateImageIds = createAliasWithWarning(
+  csToolsSyncStack,
+  "csToolsSyncStack",
+  "csToolsUpdateImageIds"
 );

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
🚀 Key Changes:

- `csToolsCreateStack` has been replaced and included in `csToolsUpdateStack` for better clarity and consistency.
- `csToolsUpdateStack` now accept `elementId` as target html element or its string id.
- `addDefaultTools` now accepts `elementId` as target html element or its string id and is no more optional.
- `csToolsCreateStack` is no longer called during rendering process.
- `disableViewport` now removes `uniqueUID` from the stored viewport.
- `unloadViewport` now does not require anymore the `seriesUID` parameter.
- `resetSeriesIds` in store has been renamed to `resetImageIds`.
- `addSeriesId` in store has been renamed to `addImageIds`.
- `removeSeriesId` in store has been renamed to `removeImageIds`.

**New Feature:** `addDefaultTools` now includes `csToolsUpdateStack` by default.
  
**Deprecated Aliases for Backward Compatibility**:
  - `csToolsUpdateImageIds → csToolsUpdateStack`
  - `csToolsCreateStack → csToolsUpdateStack`

----

The stack tools creation and synchronization process involves creating a stack object and updating it to ensure that all tools are synchronized with the current image stack.

You can create a stack object using the csToolsCreateStack function, which takes the target HTML element, image IDs, and the current image index as parameters. This function initializes the stack object and prepares it for synchronization.

You can then use the csToolsSyncStack function to update the stack object with new image IDs, ensuring that all tools are synchronized with the current image stack. This is particularly useful when working with multiple images or stacks, as it allows for seamless interaction and manipulation of the images.

If you use the addDefaultTools function, the stack tools are automatically created. This means that you don't need to manually call csToolsCreateStack or csToolsSyncStack unless you want to customize the stack behavior.

When you create the stack tool if you do not have all imageIds available, you can use the csToolsSyncStack function to update the stack object with new image IDs. This allows you to add or remove images from the stack dynamically, ensuring that all tools remain synchronized with the current image stack