### PR TITLE
Fix: convert qido metadata

### DIFF
--- a/imaging/imageParsing.ts
+++ b/imaging/imageParsing.ts
@@ -97,12 +97,20 @@ export const readFile = function (entry: File) {
 export const convertQidoMetadata = function (data: any): MetaData {
   const metadata: MetaData = Object.keys(data).reduce(
     (accumulator: any, key) => {
-      let value = data[key].Value ? data[key].Value[0] : undefined;
+      let value;
+
+      if (Array.isArray(data[key].Value)) {
+        value =
+          data[key].Value.length > 1 ? data[key].Value : data[key].Value[0];
+      } else {
+        value = undefined;
+      }
+
       // check if value is an object with key "Alphabetic"
       if (value && value.Alphabetic) {
         value = value.Alphabetic;
       }
-      // check if value is an array and fill with values
+      // check if value is a sequence and fill with values
       if (data[key].vr === "SQ") {
         value = parseSequence(value);
       }
@@ -542,7 +550,14 @@ const parseSequence = function (sequence: any): any {
       };
     }) =>
       Object.keys(item).reduce((acc: { [key: string]: any }, key) => {
-        const value = item[key]?.Value ? item[key].Value[0] : undefined;
+        let value;
+
+        if (Array.isArray(item[key]?.Value)) {
+          value =
+            item[key].Value.length > 1 ? item[key].Value : item[key].Value[0];
+        } else {
+          value = undefined;
+        }
 
         if (value && typeof value === "object" && "Alphabetic" in value) {
           acc[key.toLowerCase()] = value.Alphabetic;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
**Purpose of the PR**
This PR:

- Fixes incorrect handling of DICOM values with multiplicity > 1 (i.e., arrays with multiple items).

- Refactors parseSequence to correctly parse sequence elements, which may also contain arrays and nested sequences.

**Main Fixes in convertQidoMetadata**
-  `value = item[key]?.Value ? item[key].Value[0] : undefined; `  would return a single value if the length was 1 — `data[key].Value.length > 1 ? data[key].Value : data[key].Value[0]` this strips away the array structure even when the value should be treated as a list