### PR TITLE
Refactor image cache clearing: Separate DSA and regular image cache logic

### DIFF
--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -60,34 +60,73 @@ import { setPixelShift } from "./loaders/dsaImageLoader";
 export const clearImageCache = function (uniqueUID?: string) {
   const t0 = performance.now();
   if (uniqueUID) {
-    let series = store.get("series");
-    if (has(series, uniqueUID)) {
-      const dsaImageIds = series[uniqueUID]?.dsa?.imageIds || [];
-      const regularImageIds = series[uniqueUID]?.imageIds || [];
-
-      const allImageIds = [...dsaImageIds, ...regularImageIds];
-      each(allImageIds, function (imageId: string) {
-        if (cornerstone.imageCache.cachedImages.length > 0) {
-          try {
-            cornerstone.imageCache.removeImageLoadObject(imageId);
-          } catch (e) {
-            logger.warn("no cached image");
-          }
-        } else {
-          let uri =
-            cornerstoneDICOMImageLoader.wadouri.parseImageId(imageId).url;
-          cornerstoneDICOMImageLoader.wadouri.dataSetCacheManager.unload(uri);
-        }
-      });
-
-      store.removeImageIds(uniqueUID);
-      logger.info("Uncached images for ", uniqueUID);
-    }
+    clearStandardImageCache(uniqueUID);
+    clearDSAImageCache(uniqueUID);
   } else {
     cornerstone.imageCache.purgeCache();
   }
   const t1 = performance.now();
   logger.debug(`Call to clearImageCache took ${t1 - t0} milliseconds.`);
+};
+
+/**
+ * Purge the cornestone internal cache for standard series
+ * @instance
+ * @function clearStandardImageCache
+ * @param {String} uniqueUID - The uniqueUID of the series
+ */
+export const clearStandardImageCache = function (uniqueUID: string) {
+  const series = store.get("series");
+  const imageIds = series?.[uniqueUID]?.imageIds || [];
+
+  if (imageIds.length === 0) return;
+
+  logger.info(`Clearing image cache for ${uniqueUID}`);
+  for (const imageId of imageIds) {
+    clearCornerstoneImageCache(imageId);
+  }
+
+  store.removeImageIds(uniqueUID);
+};
+
+/**
+ * Purge the cornestone internal cache for DSA series
+ * @instance
+ * @function clearDSAImageCache
+ * @param {String} uniqueUID - The uniqueUID of the series
+ */
+export const clearDSAImageCache = function (uniqueUID: string) {
+  const dsaUID = `${uniqueUID}-DSA`;
+  const series = store.get("series");
+  const dsaImageIds = series?.[dsaUID]?.imageIds || [];
+
+  if (dsaImageIds.length === 0) return;
+
+  logger.info(`Clearing DSA image cache for ${dsaUID}`);
+  for (const imageId of dsaImageIds) {
+    clearCornerstoneImageCache(imageId);
+  }
+
+  store.removeImageIds(dsaUID);
+};
+
+/**
+ * Purge the cornestone internal cache for image
+ * @instance
+ * @function clearCornerstoneImageCache
+ * @param {String} imageId - The imageId of the image
+ */
+const clearCornerstoneImageCache = function (imageId: string) {
+  try {
+    if (cornerstone.imageCache.cachedImages.length > 0) {
+      cornerstone.imageCache.removeImageLoadObject(imageId);
+    } else {
+      const uri = cornerstoneDICOMImageLoader.wadouri.parseImageId(imageId).url;
+      cornerstoneDICOMImageLoader.wadouri.dataSetCacheManager.unload(uri);
+    }
+  } catch (e) {
+    logger.warn(`Failed to clear cache for imageId: ${imageId}`, e);
+  }
 };
 
 /**

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -62,7 +62,11 @@ export const clearImageCache = function (uniqueUID?: string) {
   if (uniqueUID) {
     let series = store.get("series");
     if (has(series, uniqueUID)) {
-      each(series[uniqueUID].imageIds, function (imageId: string) {
+      const dsaImageIds = series[uniqueUID]?.dsa?.imageIds || [];
+      const regularImageIds = series[uniqueUID]?.imageIds || [];
+
+      const allImageIds = [...dsaImageIds, ...regularImageIds];
+      each(allImageIds, function (imageId: string) {
         if (cornerstone.imageCache.cachedImages.length > 0) {
           try {
             cornerstone.imageCache.removeImageLoadObject(imageId);

--- a/index.ts
+++ b/index.ts
@@ -137,6 +137,8 @@ import {
 
 import {
   clearImageCache,
+  clearStandardImageCache,
+  clearDSAImageCache,
   loadAndCacheImages,
   renderFileImage,
   renderDICOMPDF,
@@ -374,6 +376,8 @@ export {
   convertQidoMetadata,
   // imageRendering
   clearImageCache,
+  clearStandardImageCache,
+  clearDSAImageCache,
   loadAndCacheImages,
   renderFileImage,
   renderDICOMPDF,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.4.4",
+  "version": "3.4.6",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
This PR refactors the image cache clearing logic to improve modularity, readability, and maintainability and implements DSA image cache clearing. The changes include:
- Separated image cache logic into two dedicated functions:

`clearStandardImageCache(uniqueUID: string)`

`clearDSAImageCache(uniqueUID: string)`

- Extracted shared logic into a reusable helper:

`clearSingleImageCache(imageId: string)`

