### PR TITLE
fix: reset dataSet byteArray for multiframe series

### DIFF
--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -559,11 +559,15 @@ larvitar
             //   }
             // };
 
-            larvitar.renderImage(serie, "viewer").then(() => {
-              larvitar.logger.debug("Image has been rendered");
-              hideSpinner(); // Hide the spinner when all files are processed
-              larvitar.addDefaultTools("viewer");
-            });
+            larvitar
+              .renderImage(serie, "viewer", {
+                voi: { windowCenter: 0, windowWidth: 0 }
+              })
+              .then(() => {
+                larvitar.logger.debug("Image has been rendered");
+                hideSpinner(); // Hide the spinner when all files are processed
+                larvitar.addDefaultTools("viewer");
+              });
 
             series = serie;
             const keys = Object.keys(

--- a/docs/examples/base.html
+++ b/docs/examples/base.html
@@ -559,15 +559,11 @@ larvitar
             //   }
             // };
 
-            larvitar
-              .renderImage(serie, "viewer", {
-                voi: { windowCenter: 0, windowWidth: 0 }
-              })
-              .then(() => {
-                larvitar.logger.debug("Image has been rendered");
-                hideSpinner(); // Hide the spinner when all files are processed
-                larvitar.addDefaultTools("viewer");
-              });
+            larvitar.renderImage(serie, "viewer").then(() => {
+              larvitar.logger.debug("Image has been rendered");
+              hideSpinner(); // Hide the spinner when all files are processed
+              larvitar.addDefaultTools("viewer");
+            });
 
             series = serie;
             const keys = Object.keys(

--- a/imaging/imageManagers.ts
+++ b/imaging/imageManagers.ts
@@ -157,11 +157,14 @@ export const resetImageManager = function () {
  */
 export const removeDataFromImageManager = function (uniqueUID: string) {
   if (imageManager && imageManager[uniqueUID]) {
-    if ((imageManager[uniqueUID] as Series).isMultiframe) {
-      //@ts-ignore for memory leak
-      (imageManager[uniqueUID] as Series).dataSet.byteArray = null;
+    if (imageManager[uniqueUID].isMultiframe) {
+      if (imageManager[uniqueUID].dataSet) {
+        //@ts-ignore for memory leak
+        imageManager[uniqueUID].dataSet.byteArray = null;
+      }
       (imageManager[uniqueUID] as Series).dataSet = null;
       (imageManager[uniqueUID] as Series).elements = null;
+
       clearMultiFrameCache(uniqueUID);
     }
     each(imageManager[uniqueUID].instances, function (instance) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
Fix `removeDataFromImageManager` function: in case of multiframe series, check `dataSet` existance before resetting `dataSet.byteArray` value.