### PR TITLE
fix sequence key/tags to match larvitar  standards

### DIFF
--- a/imaging/imageParsing.ts
+++ b/imaging/imageParsing.ts
@@ -553,10 +553,10 @@ const parseSequence = function (sequence: any): any {
         key
       ) => {
         const element = item[key];
-
+        const newKey = `x${key.toLowerCase()}`;
         // Handle undefined/null elements
         if (!element) {
-          acc[key.toLowerCase()] = element;
+          acc[newKey] = element;
           return acc;
         }
 
@@ -570,15 +570,15 @@ const parseSequence = function (sequence: any): any {
 
         // Handle sequence (SQ) value type with recursion
         if (element.vr === "SQ") {
-          acc[key.toLowerCase()] = parseSequence(value);
+          acc[newKey] = parseSequence(value);
           return acc;
         }
 
         // Handle special case for "Alphabetic" representation
         if (value && typeof value === "object" && "Alphabetic" in value) {
-          acc[key.toLowerCase()] = value.Alphabetic;
+          acc[newKey] = value.Alphabetic;
         } else {
-          acc[key.toLowerCase()] = value;
+          acc[newKey] = value;
         }
 
         return acc;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.4.8",
+  "version": "3.4.9",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
This PR restructures nested values so that their keys (tags) conform to the Larvitar standard format, using the pattern:
`const newKey = 'x${key.toLowerCase()}';`
This ensures consistent key naming throughout the data structure.