### PR TITLE
fix anisotropic images rendering

### DIFF
--- a/docs/api/rendering.md
+++ b/docs/api/rendering.md
@@ -129,6 +129,7 @@ All properties are optional.
    - Extracts series metadata and retrieves the appropriate image ID based on the series stack and optional `renderProps.imageIndex` value.
    - If the image ID is missing, it logs a warning and rejects the promise.
    - If `renderProps` is provided, it applies custom viewport settings.
+   - If the image is anisotropic (`rowPixelSpacing !== colPixelSpacing` checked through `isAnisotropic`), a `displayedArea` property is applied to ensure the correct maintenance of the aspect ratio.
 
 4. **Check for Series Change**
    - Determines whether the current series (`uniqueID`) differs from the previously loaded one.
@@ -396,7 +397,7 @@ This function does not return any value.
    - Throws an error if the element is not found.
 2. **Resizes the Viewport:**
    - Adjusts the size of the viewport element based on the current window dimensions.
-   - Maintains the aspect ratio and resolution settings of the viewport.
+   - Maintains the aspect ratio and resolution settings of the viewport, also for anisotropic images, by retrieving its `displayedArea` using `AnisotropicDisplayedArea`.
 
 ### Example Usage
 ```typescript

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -412,8 +412,8 @@ export const renderFileImage = function (
           return;
         }
         if (viewport.displayedArea) {
-          viewport.displayedArea.brhc.x = image.width;
-          viewport.displayedArea.brhc.y = image.height;
+          viewport.displayedArea.brhc!.x = image.width;
+          viewport.displayedArea.brhc!.y = image.height;
         }
         cornerstone.setViewport(element, viewport);
         cornerstone.fitToWindow(element);
@@ -602,7 +602,7 @@ export const getAnisotropicDisplayedArea = function (
     presentationSizeMode: "SCALE TO FIT",
     rowPixelSpacing: 1,
     columnPixelSpacing: 1
-  };
+  } as unknown as DisplayedArea;
 };
 
 /**

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -542,39 +542,57 @@ export const resizeViewport = function (elementId: string | HTMLElement) {
     return;
   }
 
-  const colPixelSpacing = store.get(["viewports", id, "spacing_x"]);
-  const rowPixelSpacing = store.get(["viewports", id, "spacing_y"]);
-
-  if (rowPixelSpacing !== colPixelSpacing) {
+  if (isAnisotropic(id)) {
     const viewport = cornerstone.getViewport(element) as Viewport;
     if (!viewport) {
       logger.error("Unable to get viewport");
       return;
     }
-    const width = store.get(["viewports", id, "cols"]);
-    const height = store.get(["viewports", id, "rows"]);
-
-    if (width === undefined || height === undefined) {
-      logger.error("Viewport dimensions are undefined");
-      return;
-    }
-
-    viewport.displayedArea = viewport.displayedArea || {
-      tlhc: { x: 0, y: 0 },
-      brhc: { x: width, y: height },
-      presentationSizeMode: "SCALE TO FIT",
-      rowPixelSpacing: 1,
-      columnPixelSpacing: 1
-    };
-
+    viewport.displayedArea = resizeAnisotropicViewport(id, viewport)!;
     cornerstone.setViewport(element, viewport);
-
-    logger.info(
-      `Anisotropic pixel spacing with aspect ratio: ${rowPixelSpacing / colPixelSpacing} - viewport updated`
-    );
   } else {
     cornerstone.resize(element, true); // true flag forces fitToWindow
   }
+};
+
+/**
+ * Check if the displayed image is anisotropic (row pixel spacing !== col pixel spacing)
+ * @instance
+ * @function isAnisotropic
+ * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
+ */
+export const isAnisotropic = function (elementId: string) {
+  const colPixelSpacing = store.get(["viewports", elementId, "spacing_x"]);
+  const rowPixelSpacing = store.get(["viewports", elementId, "spacing_y"]);
+
+  return rowPixelSpacing !== colPixelSpacing;
+};
+
+/**
+ * Resize Anisotropic Viewport through displayedArea properties
+ * @instance
+ * @function resizeAnisotropicViewport
+ * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
+ */
+export const resizeAnisotropicViewport = function (
+  id: string,
+  viewport: Viewport
+) {
+  const width = store.get(["viewports", id, "cols"]);
+  const height = store.get(["viewports", id, "rows"]);
+
+  if (width === undefined || height === undefined) {
+    logger.error("Viewport dimensions are undefined");
+    return;
+  }
+
+  return {
+    tlhc: viewport.displayedArea?.tlhc || { x: 0, y: 0 },
+    brhc: viewport.displayedArea?.brhc || { x: width, y: height },
+    presentationSizeMode: "SCALE TO FIT",
+    rowPixelSpacing: 1,
+    columnPixelSpacing: 1
+  };
 };
 
 /**
@@ -690,7 +708,7 @@ export const renderImage = function (
         }
 
         // update viewport data with default properties
-        const viewport = cornerstone.getViewport(element);
+        const viewport = cornerstone.getViewport(element) as Viewport;
         if (!viewport) {
           logger.error("viewport not found");
           reject("viewport not found for element: " + elementId);
@@ -709,7 +727,7 @@ export const renderImage = function (
         if (renderOptions.scale !== undefined) {
           // store default scale value if not specified
           if (data.default?.scale === undefined) {
-            data.default!.scale = viewport.scale;
+            data.default!.scale = viewport.scale!;
           }
           viewport.scale = renderOptions.scale;
           logger.debug(
@@ -724,11 +742,11 @@ export const renderImage = function (
               x: 0,
               y: 0
             };
-            data.default!.translation.x = viewport.translation.x || 0;
-            data.default!.translation.y = viewport.translation.y || 0;
+            data.default!.translation.x = viewport.translation!.x || 0;
+            data.default!.translation.y = viewport.translation!.y || 0;
           }
-          viewport.translation.x = renderOptions.translation.x;
-          viewport.translation.y = renderOptions.translation.y;
+          viewport.translation!.x = renderOptions.translation.x;
+          viewport.translation!.y = renderOptions.translation.y;
           logger.debug(
             `updating cornerstone viewport with custom translation values: ${renderOptions.translation.x}, ${renderOptions.translation.y}`
           );
@@ -746,13 +764,15 @@ export const renderImage = function (
         }
         // set the optional custom contrast
         if (renderOptions.voi !== undefined) {
-          viewport.voi.windowWidth = renderOptions.voi.windowWidth;
-          viewport.voi.windowCenter = renderOptions.voi.windowCenter;
+          viewport.voi!.windowWidth = renderOptions.voi.windowWidth;
+          viewport.voi!.windowCenter = renderOptions.voi.windowCenter;
           logger.debug(
             `updating cornerstone viewport with custom contrast values: ${renderOptions.voi.windowWidth}, ${renderOptions.voi.windowCenter}`
           );
         }
-
+        if (isAnisotropic(id)) {
+          viewport.displayedArea = resizeAnisotropicViewport(id, viewport)!;
+        }
         // if uniqueUID has changed update the value into the store
         if (isUniqueUIDChanged) {
           setStore(["uniqueUID", element.id, data.uniqueUID]);
@@ -764,12 +784,12 @@ export const renderImage = function (
             );
           }
           if (renderOptions.translation === undefined) {
-            viewport.translation.x = data.default?.translation.x || 0;
-            viewport.translation.y = data.default?.translation.y || 0;
+            viewport.translation!.x = data.default?.translation.x || 0;
+            viewport.translation!.y = data.default?.translation.y || 0;
             logger.debug(
               "updating cornerstone viewport with default translation values: ",
-              viewport.translation.x,
-              viewport.translation.y
+              viewport.translation!.x,
+              viewport.translation!.y
             );
           }
           if (renderOptions.rotation === undefined) {
@@ -783,14 +803,14 @@ export const renderImage = function (
           // with the default values from the series
           // if the voi is not defined in the renderOptions
           if (renderOptions.voi === undefined) {
-            viewport.voi.windowWidth =
+            viewport.voi!.windowWidth =
               data.default?.voi?.windowWidth || image.windowWidth;
-            viewport.voi.windowCenter =
+            viewport.voi!.windowCenter =
               data.default?.voi?.windowCenter || image.windowCenter;
             logger.debug(
               "updating cornerstone viewport with default voi values: ",
-              viewport.voi.windowWidth,
-              viewport.voi.windowCenter
+              viewport.voi!.windowWidth,
+              viewport.voi!.windowCenter
             );
           }
         }

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -16,6 +16,7 @@ import store, { set as setStore } from "./imageStore";
 import { applyColorMap } from "./imageColormaps";
 import { isElement } from "./imageUtils";
 import {
+  DisplayedArea,
   Instance,
   RenderProps,
   Series,
@@ -26,6 +27,7 @@ import { DEFAULT_TOOLS } from "./tools/default";
 import { initializeFileImageLoader } from "./imageLoading";
 import { generateFiles } from "./parsers/pdf";
 import { resetPixelShift, setPixelShift } from "./loaders/dsaImageLoader";
+import { ViewportComplete } from "./tools/types";
 
 /*
  * This module provides the following functions to be exported:
@@ -403,7 +405,7 @@ export const renderFileImage = function (
           return;
         }
         cornerstone.displayImage(element, image);
-        const viewport = cornerstone.getViewport(element) as Viewport;
+        const viewport = cornerstone.getViewport(element) as ViewportComplete;
 
         if (!viewport) {
           logger.error("invalid viewport");
@@ -543,7 +545,7 @@ export const resizeViewport = function (elementId: string | HTMLElement) {
   }
 
   if (isAnisotropic(id)) {
-    const viewport = cornerstone.getViewport(element) as Viewport;
+    const viewport = cornerstone.getViewport(element) as ViewportComplete;
     if (!viewport) {
       logger.error("Unable to get viewport");
       return;
@@ -560,10 +562,16 @@ export const resizeViewport = function (elementId: string | HTMLElement) {
  * @instance
  * @function isAnisotropic
  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
+ * @returns {Boolean}
  */
 export const isAnisotropic = function (elementId: string) {
   const colPixelSpacing = store.get(["viewports", elementId, "spacing_x"]);
   const rowPixelSpacing = store.get(["viewports", elementId, "spacing_y"]);
+
+  if (colPixelSpacing === undefined || rowPixelSpacing === undefined) {
+    logger.warn("colPixelSpacing or rowPixelSpacing is undefined");
+    return false;
+  }
 
   return rowPixelSpacing !== colPixelSpacing;
 };
@@ -573,10 +581,12 @@ export const isAnisotropic = function (elementId: string) {
  * @instance
  * @function getAnisotropicDisplayedArea
  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
+ * @param {ViewportComplete} viewport - The viewport
+ * @returns {DisplayedArea}
  */
 export const getAnisotropicDisplayedArea = function (
   id: string,
-  viewport: Viewport
+  viewport: ViewportComplete
 ) {
   const width = store.get(["viewports", id, "cols"]);
   const height = store.get(["viewports", id, "rows"]);
@@ -708,7 +718,7 @@ export const renderImage = function (
         }
 
         // update viewport data with default properties
-        const viewport = cornerstone.getViewport(element) as Viewport;
+        const viewport = cornerstone.getViewport(element) as ViewportComplete;
         if (!viewport) {
           logger.error("viewport not found");
           reject("viewport not found for element: " + elementId);

--- a/imaging/imageRendering.ts
+++ b/imaging/imageRendering.ts
@@ -548,7 +548,7 @@ export const resizeViewport = function (elementId: string | HTMLElement) {
       logger.error("Unable to get viewport");
       return;
     }
-    viewport.displayedArea = resizeAnisotropicViewport(id, viewport)!;
+    viewport.displayedArea = getAnisotropicDisplayedArea(id, viewport)!;
     cornerstone.setViewport(element, viewport);
   } else {
     cornerstone.resize(element, true); // true flag forces fitToWindow
@@ -569,12 +569,12 @@ export const isAnisotropic = function (elementId: string) {
 };
 
 /**
- * Resize Anisotropic Viewport through displayedArea properties
+ * Retrieves Anisotropic Viewport displayedArea properties
  * @instance
- * @function resizeAnisotropicViewport
+ * @function getAnisotropicDisplayedArea
  * @param {String} elementId - The html div id used for rendering or its DOM HTMLElement
  */
-export const resizeAnisotropicViewport = function (
+export const getAnisotropicDisplayedArea = function (
   id: string,
   viewport: Viewport
 ) {
@@ -771,7 +771,7 @@ export const renderImage = function (
           );
         }
         if (isAnisotropic(id)) {
-          viewport.displayedArea = resizeAnisotropicViewport(id, viewport)!;
+          viewport.displayedArea = getAnisotropicDisplayedArea(id, viewport)!;
         }
         // if uniqueUID has changed update the value into the store
         if (isUniqueUIDChanged) {

--- a/imaging/tools/custom/gspsTool.ts
+++ b/imaging/tools/custom/gspsTool.ts
@@ -272,9 +272,8 @@ export default class GspsTool extends BaseTool {
     if (isContrastModified) {
       resetViewports([element.id], ["contrast"]);
     }
-    const enabledElement = getEnabledElement(element) as any as {
-      viewport: ViewportComplete;
-    };
+    const enabledElement = getEnabledElement(element);
+    //@ts-ignore
     enabledElement.viewport!.displayedArea = undefined;
   }
 

--- a/imaging/tools/types.ts
+++ b/imaging/tools/types.ts
@@ -138,7 +138,7 @@ export type HandlePosition = {
 };
 export interface ViewportComplete extends Viewport {
   initialRotation: number;
-  displayedArea?: DisplayedArea;
+  displayedArea: DisplayedArea;
   scale: number;
   rotation: number;
   vflip: boolean;

--- a/imaging/tools/types.ts
+++ b/imaging/tools/types.ts
@@ -1,5 +1,5 @@
 import { EnabledElement } from "cornerstone-core";
-import { Image, Viewport } from "../types";
+import { DisplayedArea, Image, Viewport } from "../types";
 
 type ToolOptions = {
   mouseButtonMask?: number | number[];
@@ -138,7 +138,7 @@ export type HandlePosition = {
 };
 export interface ViewportComplete extends Viewport {
   initialRotation: number;
-  displayedArea: any;
+  displayedArea?: DisplayedArea;
   scale: number;
   rotation: number;
   vflip: boolean;

--- a/imaging/types.ts
+++ b/imaging/types.ts
@@ -3,7 +3,7 @@ import { DataSet } from "dicom-parser";
 import { MetaDataTypes } from "./MetaDataTypes";
 import { MetaDataReadable } from "./MetaDataReadable";
 import { Element } from "dicom-parser";
-import { Coords, Overlay } from "./tools/types";
+import { Coords, DisplayAreaVisualizations, Overlay } from "./tools/types";
 // TODO-ts: differentiate each single metadata @szanchi
 /*export type MetadataValue =
   | string
@@ -203,11 +203,11 @@ export interface Viewport extends cornerstone.Viewport {
 }
 
 export type DisplayedArea = {
-  tlhc: Coords;
-  brhc: Coords;
-  presentationSizeMode: string;
-  rowPixelSpacing: number;
-  columnPixelSpacing: number;
+  tlhc?: Coords;
+  brhc?: Coords;
+  presentationSizeMode?: DisplayAreaVisualizations;
+  rowPixelSpacing?: number;
+  columnPixelSpacing?: number;
 };
 
 export type Contours = {

--- a/imaging/types.ts
+++ b/imaging/types.ts
@@ -3,7 +3,7 @@ import { DataSet } from "dicom-parser";
 import { MetaDataTypes } from "./MetaDataTypes";
 import { MetaDataReadable } from "./MetaDataReadable";
 import { Element } from "dicom-parser";
-import { Overlay } from "./tools/types";
+import { Coords, Overlay } from "./tools/types";
 // TODO-ts: differentiate each single metadata @szanchi
 /*export type MetadataValue =
   | string
@@ -199,21 +199,16 @@ export interface Layer extends cornerstone.EnabledElementLayer {
 
 export interface Viewport extends cornerstone.Viewport {
   newImageIdIndex: number;
-  displayedArea: {
-    tlhc: {
-      x: number;
-      y: number;
-    };
-    brhc: {
-      x: number;
-      y: number;
-    };
-    columnPixelSpacing: number;
-    rowPixelSpacing: number;
-    presentationSizeMode: string;
-  };
   overlayColor?: boolean | string;
 }
+
+export type DisplayedArea = {
+  tlhc: Coords;
+  brhc: Coords;
+  presentationSizeMode: string;
+  rowPixelSpacing: number;
+  columnPixelSpacing: number;
+};
 
 export type Contours = {
   [key: string]: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.5.4",
+  "version": "3.5.6",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
### PR Title: Add Anisotropic Viewport Resize Handling for Cornerstone Viewer
**Description:**
This PR introduces a new resizeViewport utility function that resizes a Cornerstone viewport depending on whether the displayed image is anisotropic (i.e., differing row and column pixel spacing). The change ensures correct rendering behavior by adjusting the displayedArea when needed.

**Key Changes:**
- `resizeViewport`:
Accepts either a DOM element or string ID.
Determines if the target image is anisotropic using isAnisotropic.

    If anisotropic:
    Fetches the current viewport.
    Updates displayedArea to normalize spacing via resizeAnisotropicViewport.
    
    If not:
    Uses standard cornerstone.resize() with fitToWindow enabled.

- `isAnisotropic`:
Checks if the row and column pixel spacing differ for a given element ID using the global store.

- `resizeAnisotropicViewport`:
Constructs a new displayedArea with normalized pixel spacing (1:1) and mode set to "SCALE TO FIT".

**Benefits:**
Proper scaling and rendering of anisotropic images.
Improves display consistency and visual accuracy in the viewer.