### PR TITLE
Fix add tool and cs3D examples

### DIFF
--- a/docs/examples/cs3D/base.html
+++ b/docs/examples/cs3D/base.html
@@ -187,7 +187,7 @@
               .then(async ({ success, renderingEngine }) => {
                 console.log("Image has been rendered");
                 // add and enable wwwc, pan, zoom, and stack tools
-                larvitar._addDefaultTools(["viewer"], renderingEngine, "2d");
+                larvitar._addDefaultTools(["viewer"], renderingEngine, "3D");
                 hideSpinner();
               });
           })

--- a/docs/examples/cs3D/baseMpr.html
+++ b/docs/examples/cs3D/baseMpr.html
@@ -249,7 +249,7 @@
       const viewportId2 = "sagittal";
       const viewportId3 = "coronal";
       const viewportId4 = "acquisition";
-      const viewportIds = [viewportId1, viewportId2, viewportId3, viewportId4];
+      const mprViewportIds = [viewportId1, viewportId2, viewportId3];
 
       // init all
       larvitar._cornerstone.init();
@@ -309,10 +309,17 @@
                 orientation: "acquisition"
               }
             ];
+
             larvitar._renderMpr(serie, viewportInputs).then(renderingEngine => {
               console.log("Volume rendered", renderingEngine);
               // add and enable wwwc, pan, zoom, and stack tools
-              larvitar._addDefaultTools(viewportIds, renderingEngine, "mpr");
+              larvitar._addDefaultTools(mprViewportIds, renderingEngine, "MPR");
+              larvitar._addDefaultTools(
+                [viewportId4],
+                renderingEngine,
+                "3D",
+                "acquisition"
+              );
               hideSpinner();
             });
           })

--- a/docs/examples/cs3D/multiframe.html
+++ b/docs/examples/cs3D/multiframe.html
@@ -168,7 +168,7 @@
               .then(async ({ success, renderingEngine }) => {
                 console.log("Image has been rendered");
                 // add and enable wwwc, pan, zoom, and stack tools
-                larvitar._addDefaultTools("viewer", renderingEngine);
+                larvitar._addDefaultTools(["viewer"], renderingEngine);
                 hideSpinner();
               });
           })

--- a/imaging/tools/default.ts
+++ b/imaging/tools/default.ts
@@ -1086,7 +1086,15 @@ const registerExternalTool = function (
         ? DEFAULT_TOOLS_3D
         : DEFAULT_TOOLS;
 
-  dvTools[toolClass.name] = toolClass;
+  const customTools =
+    toolVersion === "MPR"
+      ? dvToolsMPR
+      : toolVersion === "3D"
+        ? dvTools3D
+        : dvTools;
+
+  customTools[toolClass.name] = toolClass;
+
   targetTools[toolName] = {
     name: toolName,
     class: toolClass.name,

--- a/imaging/tools/default.ts
+++ b/imaging/tools/default.ts
@@ -963,6 +963,20 @@ const dvTools: {
 };
 
 /**
+ * D/Vision Lab 3D custom tools
+ */
+const dvTools3D: {
+  [key: string]: any;
+} = {};
+
+/**
+ * D/Vision Lab MPR custom tools
+ */
+const dvToolsMPR: {
+  [key: string]: any;
+} = {};
+
+/**
  * Tools default style
  * Available font families :
  * Work Sans, Roboto, OpenSans, HelveticaNeue-Light,
@@ -1091,6 +1105,8 @@ export {
   DEFAULT_SETTINGS,
   DEFAULT_MOUSE_KEYS,
   dvTools,
+  dvTools3D,
+  dvToolsMPR,
   getDefaultToolsByType,
   setDefaultToolsProps,
   registerExternalTool

--- a/imaging3d/tools/custom/exampleCustomTool.ts
+++ b/imaging3d/tools/custom/exampleCustomTool.ts
@@ -3,10 +3,10 @@ import {
   getEnabledElement,
   VolumeViewport,
   cache,
-  utilities
+  utilities,
+  Viewport
 } from "@cornerstonejs/core";
 import * as EventTypes from "@cornerstonejs/tools/dist/esm/types/EventTypes";
-import { VOIRange } from "@cornerstonejs/core/dist/esm/types";
 
 // Todo: should move to configuration
 const DEFAULT_MULTIPLIER = 4;
@@ -121,8 +121,23 @@ class CustomWWWLTool extends BaseTool {
     }
   }
 
-  // @ts-ignore
-  getPTScaledNewRange({ deltaPointsCanvas, lower, upper, clientHeight, viewport, volumeId, isPreScaled }) {
+  getPTScaledNewRange({
+    deltaPointsCanvas,
+    lower,
+    upper,
+    clientHeight,
+    viewport,
+    volumeId,
+    isPreScaled
+  }: {
+    deltaPointsCanvas: number[];
+    lower: number;
+    upper: number;
+    clientHeight: number;
+    viewport: Viewport;
+    volumeId?: string;
+    isPreScaled: boolean;
+  }) {
     let multiplier = DEFAULT_MULTIPLIER;
 
     if (isPreScaled) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "4.0.0-alpha.7",
+  "version": "4.0.0-alpha.8",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
**Custom Tool Differentiation by Mode:**
Refactored customTool and allToolsList resolution using structured logic.
Explicitly separate tool resolution and activation logic for:

- 2D (e.g., cornerstone - dvTools)
- 3D (e.g., cornerstone3D -dvTools3D)
- MPR (multi-planar reconstruction - dvToolsMPR)

Prevents attempting to register or activate a 2D tool on a 3D canvas or tool group, avoiding runtime issues.

**Correct MPR Tool Activation in example:**

- Ensures MPR tools are only activated on the three orthogonal MPR canvases (axial, sagittal, coronal).
- Ensures 3D tools (e.g., volume navigation, slab rendering) are only applied to the acquisition (3D) canvas.

