### PR TITLE
fix: single frame cache cleaning with image managers

### DIFF
--- a/docs/api/modules/loaders/singleFrameLoader.md
+++ b/docs/api/modules/loaders/singleFrameLoader.md
@@ -27,6 +27,26 @@ The singleFrameLoader module is a custom DICOM loader designed to cache and rend
 
 ## Main Functions
 
+### getSingleFrameCache
+
+#### Syntax:
+
+```typescript
+getSingleFrameCache(imageId?: string): { [key: string]: SingleFrameCache }
+```
+
+#### Parameters:
+
+| Parameter	 | Type	              | Description                              |
+|------------|--------------------|------------------------------------------|
+| `imageId`	 | string             | The ID of the cached single frame.       |
+
+#### Returns:
+
+`[key: string]: SingleFrameCache` – An object containing the cached single frame data and metadata. If no ID is provided, returns all cached frames.
+
+---
+
 ### setSingleFrameCache
 
 #### Syntax:

--- a/docs/examples/singleFrame.html
+++ b/docs/examples/singleFrame.html
@@ -184,44 +184,42 @@
 
       showSpinner();
 
-      larvitar.clearSingleFrameCache();
+      larvitar.resetImageManager();
 
       const pacsURL = "http://192.168.72.141:80/dicomwebcore/";
       const wadoPrefix = "wado/";
       const qidoPrefix = "qidors/";
 
       /* STRESS ECHO 5 IMAGES */
-      // const patientID = "TEST_FIVEMF_STRESS";
-      // const studyID =
-      //   "1.2.826.0.1.3680043.2.97.4.2017.1247782231.250207090009398";
-      // const seriesInstanceUID =
-      //   "1.2.826.0.1.3680043.2.97.4.2017.1044975747.250207090029960";
+      const patientID = "TEST_FIVEMF_STRESS";
+      const studyID =
+        "1.2.826.0.1.3680043.2.97.4.2017.1247782231.250207090009398";
+      const seriesInstanceUID =
+        "1.2.826.0.1.3680043.2.97.4.2017.1044975747.250207090029960";
 
-      // const instanceUID_1 =
-      //   "1.2.826.0.1.3680043.2.97.19529.21573.851230414.250207090046713";
-      // const instanceUID_2 =
-      //   "1.2.826.0.1.3680043.2.97.19529.21573.486881842.250207090047588";
-      // const instanceUID_3 =
-      //   "1.2.826.0.1.3680043.2.97.19529.21573.1383892180.2502070900458070";
-      // const instanceUID_4 =
-      //   "1.2.826.0.1.3680043.2.97.19529.21573.4271180931.2502070900450260";
-      // const instanceUID_5 =
-      //   "1.2.826.0.1.3680043.2.97.19529.21573.1888853007.2502070900482760";
+      const instanceUID_1 =
+        "1.2.826.0.1.3680043.2.97.19529.21573.851230414.250207090046713";
+      const instanceUID_2 =
+        "1.2.826.0.1.3680043.2.97.19529.21573.486881842.250207090047588";
+      const instanceUID_3 =
+        "1.2.826.0.1.3680043.2.97.19529.21573.1383892180.2502070900458070";
+      const instanceUID_4 =
+        "1.2.826.0.1.3680043.2.97.19529.21573.4271180931.2502070900450260";
+      const instanceUID_5 =
+        "1.2.826.0.1.3680043.2.97.19529.21573.1888853007.2502070900482760";
       /* END STRESS ECHO 5 IMAGES */
 
       /* XA 2 IMAGES */
+      // const patientID = "";
+      // const studyID =
+      //   "1.2.826.0.1.3680043.2.97.19529.21573.56762315.2305111440116770";
+      // const seriesInstanceUID =
+      //   "1.3.12.2.1107.5.4.5.153909.30000023032704445857800005582";
 
-      const patientID = "";
-      const studyID =
-        "1.2.826.0.1.3680043.2.97.19529.21573.56762315.2305111440116770";
-      const seriesInstanceUID =
-        "1.3.12.2.1107.5.4.5.153909.30000023032704445857800005582";
-
-      const instanceUID_1 =
-        "1.3.12.2.1107.5.4.5.153909.30000023032704445857800005609.512";
-      const instanceUID_2 =
-        "1.3.12.2.1107.5.4.5.153909.30000023032704445857800005610.512";
-
+      // const instanceUID_1 =
+      //   "1.3.12.2.1107.5.4.5.153909.30000023032704445857800005609.512";
+      // const instanceUID_2 =
+      //   "1.3.12.2.1107.5.4.5.153909.30000023032704445857800005610.512";
       /* END XA 2 IMAGES */
 
       const qidoUrl = `${pacsURL}${qidoPrefix}instances?SeriesInstanceUID=${seriesInstanceUID}&StudyInstanceUID=${studyID}&PatientID=${patientID}&includefield=header`;
@@ -297,19 +295,19 @@
               "Call to renderImage took " + (t1 - t0) + " milliseconds."
             );
             hideSpinner();
-            const trace_data = renderSeriesECG(
-              instanceUID,
-              dicomSerie,
-              canvasId
-            );
+            // const trace_data = renderSeriesECG(
+            //   instanceUID,
+            //   dicomSerie,
+            //   canvasId
+            // );
             // cine LOOP
             if (frameId === 0) {
-              //larvitar.addDefaultTools("viewer-1");
-              //larvitar.addDefaultTools("viewer-2");
-              //larvitar.addDefaultTools("viewer-3");
-              //larvitar.addDefaultTools("viewer-4");
-              //larvitar.addDefaultTools("viewer-5");
-              larvitar.addDefaultTools(canvasId);
+              larvitar.addDefaultTools("viewer-1");
+              larvitar.addDefaultTools("viewer-2");
+              larvitar.addDefaultTools("viewer-3");
+              larvitar.addDefaultTools("viewer-4");
+              larvitar.addDefaultTools("viewer-5");
+              //larvitar.addDefaultTools(canvasId);
               larvitar.setToolActive("StackScroll");
               if (AUTO_PLAY === true) {
                 frameId++;
@@ -346,14 +344,14 @@
                     cached: true,
                     imageIndex: currentFrameId
                   });
-                  if (trace_data) {
-                    larvitar.updateECGMarker(
-                      trace_data,
-                      currentFrameId,
-                      numberOfFrames,
-                      "ecg" + " - " + canvasId
-                    );
-                  }
+                  // if (trace_data) {
+                  //   larvitar.updateECGMarker(
+                  //     trace_data,
+                  //     currentFrameId,
+                  //     numberOfFrames,
+                  //     "ecg" + " - " + canvasId
+                  //   );
+                  // }
                   frameId =
                     currentFrameId == numberOfFrames - 1
                       ? 0
@@ -383,9 +381,9 @@
         });
         cacheFrames(instanceUID_1, metadata[instanceUID_1], "viewer-1");
         cacheFrames(instanceUID_2, metadata[instanceUID_2], "viewer-2");
-        //cacheFrames(instanceUID_3, metadata[instanceUID_3], "viewer-3");
-        //cacheFrames(instanceUID_4, metadata[instanceUID_4], "viewer-4");
-        //cacheFrames(instanceUID_5, metadata[instanceUID_5], "viewer-5");
+        cacheFrames(instanceUID_3, metadata[instanceUID_3], "viewer-3");
+        cacheFrames(instanceUID_4, metadata[instanceUID_4], "viewer-4");
+        cacheFrames(instanceUID_5, metadata[instanceUID_5], "viewer-5");
       })();
 
       const renderSeriesECG = function (

--- a/imaging/imageManagers.ts
+++ b/imaging/imageManagers.ts
@@ -22,6 +22,7 @@ import type {
 } from "./types";
 import { getFileCustomImageId } from "./loaders/fileLoader";
 import { logger } from "../logger";
+import { clearSingleFrameCache } from "./loaders/singleFrameLoader";
 
 // global variables
 var imageManager: ImageManager = null;
@@ -143,6 +144,7 @@ export const resetImageManager = function () {
   });
   imageManager = null;
   imageTracker = null;
+  clearSingleFrameCache();
   let t1 = performance.now();
   logger.debug(
     "Call to resetImageManager took " + (t1 - t0) + " milliseconds."
@@ -153,7 +155,7 @@ export const resetImageManager = function () {
  * Remove a stored seriesId from the image manager
  * @instance
  * @function removeDataFromImageManager
- * @param {String} seriesId The Id of the series
+ * @param {String} uniqueUID The Id of the series
  */
 export const removeDataFromImageManager = function (uniqueUID: string) {
   if (imageManager && imageManager[uniqueUID]) {
@@ -167,7 +169,8 @@ export const removeDataFromImageManager = function (uniqueUID: string) {
 
       clearMultiFrameCache(uniqueUID);
     }
-    each(imageManager[uniqueUID].instances, function (instance) {
+    each(imageManager[uniqueUID].instances, function (instance, imageId) {
+      clearSingleFrameCache(imageId);
       if (instance.dataSet) {
         //@ts-ignore for memory leak
         instance.dataSet.byteArray = null;

--- a/imaging/loaders/singleFrameLoader.ts
+++ b/imaging/loaders/singleFrameLoader.ts
@@ -29,6 +29,22 @@ let singleFrameCache: { [key: string]: SingleFrameCache } = {};
  */
 
 /**
+ * Get the single frame cache
+ * @export
+ * @function getSingleFrameCache
+ * @param {String} imageId - Optional Image tag
+ * @returns {Object} - Single frame cache object
+ */
+export const getSingleFrameCache = function (imageId?: string): {
+  [key: string]: SingleFrameCache;
+} {
+  if (imageId) {
+    return { [imageId]: singleFrameCache[imageId] };
+  }
+  return singleFrameCache;
+};
+
+/**
  * Set the single frame cache
  * @export
  * @function setSingleFrameCache
@@ -69,18 +85,19 @@ export const setSingleFrameCache = async function (
  * @param {String} imageId - Optional Image tag
  */
 export const clearSingleFrameCache = function (imageId?: string): void {
-  if (imageId) {
+  if (imageId && singleFrameCache[imageId]) {
     // @ts-ignore: is needed to clear the cache
     singleFrameCache[imageId].pixelData = null;
     // @ts-ignore: is needed to clear the cache
     singleFrameCache[imageId].metadata = null;
     delete singleFrameCache[imageId];
   } else {
-    Object.values(singleFrameCache).forEach(element => {
+    Object.values(singleFrameCache).forEach((element, imageId) => {
       // @ts-ignore: is needed to clear the cache
       element.pixelData = null;
       // @ts-ignore: is needed to clear the cache
       element.metadata = null;
+      delete singleFrameCache[imageId];
     });
     singleFrameCache = {};
   }
@@ -304,8 +321,6 @@ const createCustomImage = function (imageId: string): ImageLoadObject {
           image.windowCenter = (maxVoi + minVoi) / 2;
         }
       }
-
-      clearSingleFrameCache(imageId);
 
       resolve(image as Image);
     }, reject);

--- a/index.ts
+++ b/index.ts
@@ -249,6 +249,7 @@ import {
 
 import {
   setSingleFrameCache,
+  getSingleFrameCache,
   clearSingleFrameCache,
   loadSingleFrameImage
 } from "./imaging/loaders/singleFrameLoader";
@@ -454,6 +455,7 @@ export {
   clearMultiFrameCache,
   // loaders/singleFrameLoader
   setSingleFrameCache,
+  getSingleFrameCache,
   clearSingleFrameCache,
   loadSingleFrameImage,
   // loaders/dsaImageLoader

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
This pull request introduces improvements to single-frame DICOM image cache management and updates the example code to better demonstrate multi-frame handling. The main changes include the addition of a method to access the single-frame cache, enhanced cache clearing logic and documentation updates.

**Single-frame cache management:**

* Added a new `getSingleFrameCache` function to allow retrieval of cached single-frame data by image ID or for all images, and exported it in `index.ts` for external use. 
* Improved `clearSingleFrameCache` to ensure cache entries are properly deleted when clearing by image ID or clearing all entries.
* Updated cache clearing logic in `resetImageManager` and `removeDataFromImageManager` to invoke `clearSingleFrameCache` for each relevant image, ensuring memory is released when image manager data is removed.
* 
**Example and documentation updates:**

* Added documentation for the new `getSingleFrameCache` function in the API docs.

**Other changes:**

* Bumped the package version from `3.6.5` to `3.6.6` in `package.json`.
* Minor parameter naming improvement in `removeDataFromImageManager` for clarity.

These changes collectively improve cache management for single-frame DICOM images and make the example code more illustrative for users working with multiple frames.