### PR TITLE
fix: frame number in updateLoadedStack

### DIFF
--- a/imaging/imageLoading.ts
+++ b/imaging/imageLoading.ts
@@ -287,7 +287,10 @@ export const updateLoadedStack = function (
 
     // store needed instance tags
     allSeriesStack[id].instances[imageId] = {
-      frame: sliceIndex ? sliceIndex : allSeriesStack[id].imageIds.length - 1,
+      frame:
+        sliceIndex !== undefined || sliceIndex !== null
+          ? sliceIndex
+          : allSeriesStack[id].imageIds.length - 1,
       instanceId: iid,
       metadata: seriesData.metadata
     };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "medical",
     "cornerstone"
   ],
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "typescript library for parsing, loading, rendering and interacting with DICOM images",
   "repository": {
     "url": "https://github.com/dvisionlab/Larvitar.git",


### PR DESCRIPTION
* Updated the conditional logic for determining the `frame` value.
* Previously, the check used `sliceIndex ? sliceIndex : fallback`, which caused `0` to be treated as falsy and incorrectly replaced with the fallback value.
* Replaced it with an explicit null/undefined check:

```js
frame:
  sliceIndex !== undefined && sliceIndex !== null
    ? sliceIndex
    : allSeriesStack[id].imageIds.length - 1,
```